### PR TITLE
Add metadata and plugins

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -3,6 +3,7 @@
 import argparse
 from expvar.stats import stats
 import logging
+import os
 import sys
 from threading import Thread
 from time import sleep
@@ -14,7 +15,7 @@ import grouper
 from grouper.api.routes import HANDLERS
 from grouper.api.settings import settings
 from grouper.graph import GroupGraph
-from grouper.models import get_db_engine, Session
+from grouper.models import get_db_engine, Session, load_plugins
 from grouper.util import get_loglevel, get_database_url
 
 
@@ -76,6 +77,12 @@ def main(argv):
 
     if log_level < 0:
         sa_log.setLevel(logging.INFO)
+
+    if settings.plugin_dir:
+        if not os.path.exists(settings.plugin_dir):
+            logging.fatal("Plugin directory does not exist")
+            sys.exit(1)
+        load_plugins(settings.plugin_dir)
 
     tornado_settings = {
         "debug": settings.debug,

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -8,7 +8,7 @@ import tornado.ioloop
 import tornado.httpserver
 import tornado.web
 
-from grouper.models import get_db_engine, Session
+from grouper.models import get_db_engine, Session, load_plugins
 from grouper.util import get_loglevel, get_database_url
 
 import grouper.fe
@@ -47,6 +47,12 @@ def main(argv):
     if settings.debug and settings.num_processes > 1:
         logging.fatal("Debug mode does not support multiple processes.")
         sys.exit(1)
+
+    if settings.plugin_dir:
+        if not os.path.exists(settings.plugin_dir):
+            logging.fatal("Plugin directory does not exist")
+            sys.exit(1)
+        load_plugins(settings.plugin_dir)
 
     log_level = get_loglevel(args)
     logging.basicConfig(

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -17,6 +17,11 @@ common:
     # Type: str
     log_format: "%(asctime)-15s\t%(levelname)s\t%(message)s"
 
+    # Directory for plugins. If set, load plugins from this directory. Plugins can affect the
+    # behavior of Grouper.
+    # Type: str
+    plugin_dir: ""
+
 fe:
     # Number of worker processes to fork for receving requests. This option
     # is mutually exclusive with debug.

--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -10,7 +10,7 @@ NAME2_VALIDATION = r"(?P<name2>[@\-\w\.]+)"
 # Regexes for validating permission/argument names
 PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+)"
 PERMISSION_WILDCARD_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+(?:\.\*)?)"
-ARGUMENT_VALIDATION = r"(?P<argument>|\*|[\w=/.-]+\*?)"
+ARGUMENT_VALIDATION = r"(?P<argument>|\*|[\w=/.:-]+\*?)"
 
 # Global permission names to prevent stringly typed things
 PERMISSION_GRANT = "grouper.permission.grant"

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -116,6 +116,13 @@ class GroupGraph(object):
                         "created_on": str(key.created_on),
                     } for key in user.my_public_keys()
                 ],
+                "metadata": [
+                    {
+                        "data_key": row.data_key,
+                        "data_value": row.data_value,
+                        "last_modified": str(row.last_modified),
+                    } for row in user.my_metadata()
+                ],
             }
         return out
 

--- a/grouper/plugin.py
+++ b/grouper/plugin.py
@@ -1,0 +1,22 @@
+"""
+plugin.py
+
+Base plugin for Grouper plugins. These are plugins that can be written to extend Grouper
+functionality.
+"""
+
+
+class BasePlugin(object):
+    def user_created(self, user):
+        """Called when a new user is created
+
+        When new users enter into Grouper, you might have reason to set metadata on those
+        users for some reason. This method is called when that happens.
+
+        Args:
+            user (models.User): Object of new user.
+
+        Returns:
+            The return code of this method is ignored.
+        """
+        pass

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -48,4 +48,5 @@ settings = Settings({
     "database": None,
     "database_source": None,
     "log_format": "%(asctime)-15s\t%(levelname)s\t%(message)s",
+    "plugin_dir": None,
 })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+annex==0.3.1
 Jinja2==2.7.3
 MySQL-python==1.2.5
 MarkupSafe==0.23

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -3,7 +3,7 @@ from fixtures import users, graph, groups, session, permissions  # noqa
 from util import get_users, get_groups, add_member
 
 
-def setup_desc_to_ances(session, users, groups):
+def setup_desc_to_ances(session, users, groups):  # noqa
     add_member(groups["team-sre"], users["gary"], role="owner")
     add_member(groups["team-sre"], users["zay"])
 
@@ -18,7 +18,7 @@ def setup_desc_to_ances(session, users, groups):
     add_member(groups["all-teams"], groups["team-infra"])
 
 
-def test_graph_desc_to_ances(session, graph, users, groups):
+def test_graph_desc_to_ances(session, graph, users, groups):  # noqa
     """ Test adding members where all descendants already exist."""
 
     setup_desc_to_ances(session, users, groups)
@@ -44,7 +44,7 @@ def test_graph_desc_to_ances(session, graph, users, groups):
     assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
 
 
-def test_graph_add_member_existing(session, graph, users, groups):
+def test_graph_add_member_existing(session, graph, users, groups):  # noqa
     """ Test adding members to an existing relationship."""
 
     add_member(groups["team-sre"], users["gary"], role="owner")
@@ -82,7 +82,7 @@ def test_graph_add_member_existing(session, graph, users, groups):
     assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
 
 
-def test_graph_with_removes(session, graph, users, groups):
+def test_graph_with_removes(session, graph, users, groups):  # noqa
     """ Test adding members where all descendants already exist."""
 
     setup_desc_to_ances(session, users, groups)
@@ -151,7 +151,7 @@ def test_graph_with_removes(session, graph, users, groups):
     assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
 
 
-def test_graph_cycle_direct(session, graph, users, groups):
+def test_graph_cycle_direct(session, graph, users, groups):  # noqa
     """ Test adding members where all descendants already exist."""
 
     add_member(groups["team-sre"], users["gary"])
@@ -175,7 +175,7 @@ def test_graph_cycle_direct(session, graph, users, groups):
     assert get_groups(graph, "zay", cutoff=1) == set(["tech-ops"])
 
 
-def test_graph_cycle_indirect(session, graph, users, groups):
+def test_graph_cycle_indirect(session, graph, users, groups):  # noqa
     """ Test adding a member that will create a cycle.
 
         gary         zay            testuser

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -3,7 +3,7 @@ from fixtures import standard_graph, graph, users, groups, session, permissions 
 from util import grant_permission, get_group_permissions, get_user_permissions
 
 
-def test_basic_permission(standard_graph, session, users, groups, permissions):
+def test_basic_permission(standard_graph, session, users, groups, permissions):  # noqa
     """ Test adding some permissions to various groups and ensuring that the permissions are all
         implemented as expected. This also tests permissions inheritance in the graph. """
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,35 @@
+from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
+
+
+def test_basic_metadata(standard_graph, session, users, groups, permissions):  # noqa
+    """ Test basic metadata functionality. """
+
+    graph = standard_graph  # noqa
+
+    assert len(users["zorkian"].my_metadata()) == 0, "No metadata yet"
+
+    # Test setting "foo" to 1 works, and we get "1" back (metadata is defined as strings)
+    users["zorkian"].set_metadata("foo", 1)
+    md = users["zorkian"].my_metadata()
+    assert len(md) == 1, "One metadata item"
+    assert [d.data_value for d in md if d.data_key == "foo"] == ["1"], "foo is 1"
+
+    users["zorkian"].set_metadata("bar", "test string")
+    md = users["zorkian"].my_metadata()
+    assert len(md) == 2, "Two metadata items"
+    assert [d.data_value for d in md if d.data_key == "bar"] == ["test string"], \
+        "bar is test string"
+
+    users["zorkian"].set_metadata("foo", "test2")
+    md = users["zorkian"].my_metadata()
+    assert len(md) == 2, "Two metadata items"
+    assert [d.data_value for d in md if d.data_key == "foo"] == ["test2"], "foo is test2"
+
+    users["zorkian"].set_metadata("foo", None)
+    md = users["zorkian"].my_metadata()
+    assert len(md) == 1, "One metadata item"
+    assert [d.data_value for d in md if d.data_key == "foo"] == [], "foo is not found"
+
+    users["zorkian"].set_metadata("baz", None)
+    md = users["zorkian"].my_metadata()
+    assert len(md) == 1, "One metadata item"


### PR DESCRIPTION
This adds a very basic metadata (key, value) storage system, which can
be used by people who want to do things when accounts are set up, etc.
The plugins can be configured in the config_dir and apply to both the
API and FE servers.