### PR TITLE
Let the frontend have the graph

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -18,7 +18,6 @@ from grouper.graph import GroupGraph
 from grouper.models import get_db_engine, Session, load_plugins
 from grouper.util import get_loglevel, get_database_url
 
-
 from sqlalchemy.exc import OperationalError
 
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 
 import argparse
+from expvar.stats import stats
 import logging
 import os
 import sys
+from threading import Thread
+from time import sleep
 import tornado.ioloop
 import tornado.httpserver
 import tornado.web
 
+from grouper.graph import GroupGraph
 from grouper.models import get_db_engine, Session, load_plugins
 from grouper.util import get_loglevel, get_database_url
 
@@ -16,6 +20,7 @@ from grouper.fe.routes import HANDLERS
 from grouper.fe.util import get_template_env
 from grouper.fe.settings import settings
 
+from sqlalchemy.exc import OperationalError
 
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
@@ -24,6 +29,29 @@ class Application(tornado.web.Application):
     def __init__(self, *args, **kwargs):
         self.my_settings = kwargs.pop("my_settings", {})
         super(Application, self).__init__(*args, **kwargs)
+
+
+class DbRefreshThread(Thread):
+    def __init__(self, graph, refresh_interval, *args, **kwargs):
+        self.graph = graph
+        self.refresh_interval = refresh_interval
+        Thread.__init__(self, *args, **kwargs)
+
+    def run(self):
+
+        while True:
+            sleep(self.refresh_interval)
+
+            logging.debug("Updating Graph from Database.")
+            try:
+                session = Session()
+                self.graph.update_from_db(session)
+                session.close()
+                stats.set_gauge("successful-db-update", 1)
+            except OperationalError:
+                Session.configure(bind=get_db_engine(get_database_url(settings)))
+                logging.critical("Failed to connect to database.")
+                stats.set_gauge("successful-db-update", 0)
 
 
 def main(argv):
@@ -73,12 +101,22 @@ def main(argv):
 
     Session.configure(bind=get_db_engine(get_database_url(settings)))
 
+    logging.info("Initilializing graph data.")
+    session = Session()
+    graph = GroupGraph.from_db(session)
+    session.close()
+
     my_settings = {
         "db_session": Session,
+        "graph": graph,
         "template_env": template_env,
     }
 
     application = Application(HANDLERS, my_settings=my_settings, **tornado_settings)
+
+    refresher = DbRefreshThread(graph, settings.refresh_interval)
+    refresher.daemon = True
+    refresher.start()
 
     port = args.port or settings.port
 

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -73,6 +73,10 @@ fe:
     # Type: str
     smtp_server: "localhost"
 
+    # How often to pull cache data from database in seconds.
+    # Type: int
+    refresh_interval: 10
+
 api:
     # The port to listen to requests on.
     # Type: int

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -17,7 +17,7 @@ from .forms import (
 from ..models import (
     User, Group, Request, PublicKey, Permission, PermissionMap, AuditLog, GroupEdge,
     GROUP_JOIN_CHOICES, REQUEST_STATUS_CHOICES, GROUP_EDGE_ROLES, OBJ_TYPES,
-    get_user_or_group,
+    get_user_or_group, Plugins,
 )
 from .util import GrouperHandler, Alert
 from ..util import matches_glob
@@ -87,9 +87,11 @@ class UserView(GrouperHandler):
         if (user.name == self.current_user.name) or self.current_user.user_admin:
             can_control = True
 
+        user_md = self.graph.get_user_details(user.name)
+
         groups = user.my_groups()
         public_keys = user.my_public_keys()
-        permissions = user.my_permissions()
+        permissions = user_md.get('permissions', [])
         log_entries = user.my_log_entries()
         self.render("user.html", user=user, groups=groups, public_keys=public_keys,
                     can_control=can_control, permissions=permissions,
@@ -400,9 +402,11 @@ class GroupView(GrouperHandler):
 
         grantable = self.current_user.my_grantable_permissions()
 
+        group_md = self.graph.get_group_details(group.name)
+
         members = group.my_members()
         groups = group.my_groups()
-        permissions = group.my_permissions()
+        permissions = group_md.get('permissions', [])
         log_entries = group.my_log_entries()
 
         num_pending = group.my_requests("pending").count()

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -22,6 +22,7 @@ settings = FeSettings.from_settings(base_settings, {
     "date_format": "%Y-%m-%d %I:%M %p",
     "cdnjs_prefix": "//cdnjs.cloudflare.com",
     "user_auth_header": "X-Grouper-User",
+    "refresh_interval": 60,
     "send_emails": True,
     "smtp_server": "localhost",
     "from_addr": "no-reply@grouper.local",

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -87,10 +87,24 @@
     </div>
 {%- endmacro %}
 
-{% macro account(user) -%}
-<a href="/{{user.type|lower}}s/{{user.name}}">
-    <i class="fa fa-user{% if user.type == 'Group' %}s{% endif %}"></i> 
+{% macro account(user, type=None) -%}
+{% if type == None %}
+<a href="/{{ user.type | lower }}s/{{ user.name }}">
+    <i class="fa fa-user{% if user.type.lower() == 'group' %}s{% endif %}"></i> 
     {{ user.name }}
+</a>
+{% else %}
+<a href="/{{ type | lower }}s/{{ user }}">
+    <i class="fa fa-user{% if type.lower() == 'group' %}s{% endif %}"></i> 
+    {{ user }}
+</a>
+{% endif %}
+{%- endmacro %}
+
+{% macro permission(perm) -%}
+<a href="/permission/{{perm.name or perm.permission}}">
+    <i class="fa fa-key"></i>
+    {{perm.name or perm.permission}}
 </a>
 {%- endmacro %}
 
@@ -187,7 +201,7 @@
                                 Group: {{ account(entry.on_group) }}<br />
                             {% endif %}
                             {% if entry.on_permission %}
-                                Permission: <a href="/permission/{{ entry.on_permission.name }}">{{ entry.on_permission.name }}</a><br />
+                                Permission: {{ permission(entry.on_permission) }}<br />
                             {% endif %}
                             {% if entry.on_user %}
                                 User: {{ account(entry.on_user) }}<br />
@@ -208,7 +222,7 @@
     </div>
 {%- endmacro %}
 
-{% macro permission_panel(max_height, mappings, group=None, can_grant=None, show_via=False) -%}
+{% macro permission_panel(max_height, mappings, group=None, can_grant=None) -%}
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">My Permissions</h3>
@@ -223,9 +237,7 @@
                     <tr>
                         <th class="col-sm-2">Permission</th>
                         <th class="col-sm-2">Argument</th>
-                        {% if show_via %}
-                            <th class="col-sm-2">From Group</th>
-                        {% endif %}
+                        <th class="col-sm-2">From Group</th>
                         {% if can_grant %}
                             <th class="col-sm-2"></th>
                         {% endif %}
@@ -234,38 +246,30 @@
                 <tbody>
                 {% for map in mappings %}
                     <tr>
-                        <td><a href="/permission/{{map.name}}">{{ map.name }}</a></td>
-                        <td class="col-sm-2">{{map.argument|default("(unargumented)", True)}}</td>
-                        {% if show_via %}
-                            <td class="col-sm-2">{{ account(map.Group) }}</td>
+                        <td>{{ permission(map) }}</td>
+                        <td class="col-sm-2">{{ map.argument|default("(unargumented)", True) }}</td>
+                        <td class="col-sm-2">
+                        {% if map.distance == 0 %}
+                            (direct)
+                        {% else %}
+                            {{ account(map.path[-1], type='group') }}
                         {% endif %}
+                        </td>
                         {% if can_grant %}
                             <td class="col-sm-2">
-                            {% for grantable in can_grant if grantable[0].name == map.name %}
+                            {% if map.distance == 0 %}
+                            {% for grantable in can_grant if grantable[0].name == map.permission %}
                                 {% if loop.first %}
                                     <a class="btn btn-default btn-xs" href="/permissions/{{ map.name }}/revoke/{{ map.mapping_id }}">
                                     <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span> Revoke
                                     </a>
                                 {% endif %}
                             {% endfor %}
+                            {% endif %}
                             </td>
                         {% endif %}
                     </tr>
                 {% endfor %}
-                {% if show_via %}
-                    <tr>
-                        <td colspan="5" class="text-center"><strong>
-                            Only direct permissions granted from a group you are a member of are shown.
-                            Permissions indirectly granted are not shown.
-                        </strong></td>
-                    </tr>
-                {% else %}
-                    <tr>
-                        <td colspan="5" class="text-center"><strong>
-                            Only permissions that this group grants are shown here.
-                        </strong></td>
-                    </tr>
-                {% endif %}
                 {% if not mappings %}
                     <tr>
                         <td colspan="5" class="text-center">

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import paginator, dropdown with context %}
+{% from 'macros/ui.html' import permission, paginator, dropdown with context %}
 
 {% block heading %}
     Permissions
@@ -29,10 +29,10 @@
                 </tr>
             </thead>
             <tbody>
-            {% for permission in permissions %}
+            {% for perm in permissions %}
                 <tr>
-                    <td><a href="/permission/{{permission.name}}">{{permission.name}}</a></td>
-                    <td>{{permission.description|default("", True)|escape}}</td>
+                    <td>{{ permission(perm) }}</td>
+                    <td>{{ perm.description|default("", True) | escape }}</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -35,7 +35,7 @@
 </div>
 <div class="row">
     <div class="col-md-12">
-        {{ permission_panel(400, permissions, show_via=True) }}
+        {{ permission_panel(400, permissions) }}
     </div>
 </div>
 <div class="row">

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -36,9 +36,9 @@ class InvalidUser(Exception):
 
 
 class GrouperHandler(tornado.web.RequestHandler):
-
     def initialize(self):
         self.session = self.application.my_settings.get("db_session")()
+        self.graph = self.application.my_settings.get("graph")
         stats.incr("requests")
 
     def _handle_request_exception(self, e):


### PR DESCRIPTION
It was confusing that the permissions view would only show direct
permissions, instead of letting you see all permissions. Instead of
walking the graph every time we needed this data, let's just load the
graph into the frontend worker with a customizable refresh.

This is potentially adding a lot of data/load to the frontend, and
now every fe worker has to load the graph. In my testing this seems
reasonable. There are things we can do to avoid the FE loading extra
metadata if we need to.