### PR TITLE
Add some more text + on/off button

### DIFF
--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -4,8 +4,16 @@ from ..constants import NAME_VALIDATION, NAME2_VALIDATION, PERMISSION_VALIDATION
 HANDLERS = [
     (r"/", handlers.Index),
     (r"/groups", handlers.GroupsView),
-    (r"/permission/{}".format(PERMISSION_VALIDATION), handlers.PermissionView),
+    (r"/permissions/{}".format(PERMISSION_VALIDATION), handlers.PermissionView),
     (r"/permissions", handlers.PermissionsView),
+    (
+        r"/permissions/{}/enable-auditing".format(PERMISSION_VALIDATION),
+        handlers.PermissionEnableAuditing
+    ),
+    (
+        r"/permissions/{}/disable-auditing".format(PERMISSION_VALIDATION),
+        handlers.PermissionDisableAuditing
+    ),
     (r"/permissions/create", handlers.PermissionsCreate),
     (r"/permissions/grant/{}".format(NAME_VALIDATION), handlers.PermissionsGrant),
     (

--- a/grouper/fe/static/css/grouper.css
+++ b/grouper/fe/static/css/grouper.css
@@ -265,3 +265,7 @@ span.disabled {
     word-break: break-all;
     white-space: normal;
 }
+
+.account-link, .permission-link {
+    white-space: nowrap;
+}

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -17,6 +17,12 @@
                 <h3 class="panel-title">Join Group</h3>
            </div>
             <div class="panel-body">
+                {% if audited %}
+                <div class="alert alert-warning">
+                    <strong>Membership in this group is audited.</strong> Your access to this
+                    group will be regularly reviewed according to the production access policy.
+                </div>
+                {% endif %}
                 <form class="form-horizontal" role="form"
                       method="post" action="/groups/{{group.name}}/join">
                     {% include "forms/group-join.html" %}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -111,12 +111,12 @@
 
 {% macro account(user, type=None) -%}
 {% if type == None %}
-<a href="/{{ user.type | lower }}s/{{ user.name }}">
+<a class="account-link" href="/{{ user.type | lower }}s/{{ user.name }}">
     <i class="fa fa-user{% if user.type.lower() == 'group' %}s{% endif %}"></i> 
     {{ user.name }}
 </a>
 {% else %}
-<a href="/{{ type | lower }}s/{{ user }}">
+<a class="account-link" href="/{{ type | lower }}s/{{ user }}">
     <i class="fa fa-user{% if type.lower() == 'group' %}s{% endif %}"></i> 
     {{ user }}
 </a>
@@ -124,7 +124,7 @@
 {%- endmacro %}
 
 {% macro permission(perm) -%}
-<a href="/permission/{{perm.name or perm.permission}}">
+<a class="permission-link" href="/permissions/{{perm.name or perm.permission}}">
     <i class="fa fa-key"></i>
     {{perm.name or perm.permission}}
 </a>

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -9,9 +9,30 @@
     {{ permission.name }}
 {% endblock %}
 
+{% block headingbuttons %}
+    {% if current_user.permission_admin %}
+        {% if permission.audited %}
+            <button class="btn btn-danger" data-toggle="modal" data-target="#disableModal">
+                <i class="fa fa-minus"></i> Disable Auditing
+            </button>
+        {% else %}
+            <button class="btn btn-warning" data-toggle="modal" data-target="#enableModal">
+                <i class="fa fa-plus"></i> Enable Auditing
+            </button>
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block content %}
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
+        {% if permission.audited %}
+        <div class="alert alert-warning">
+            <strong>This is an audited permission.</strong> Any group this permission is applied
+            to will become audited.
+        </div>
+        {% endif %}
+
         <table class="table table-elist">
             <thead>
                 <tr>
@@ -40,6 +61,60 @@
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
         {{ log_entry_panel(400, log_entries) }}
+    </div>
+</div>
+
+<div class="modal fade" id="enableModal" tabindex="-1" role="dialog"
+      aria-labelledby="enableModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Enable Auditing</h4>
+           </div>
+            <div class="modal-body">
+                <p>Are you sure you want to enable auditing for this permission?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default"
+                        data-dismiss="modal">Close</button>
+                <form action="/permissions/{{permission.name}}/enable-auditing" method="post"
+                      style="display: inline;">
+                    {{ xsrf_form() }}
+                    <button type="submit" class="btn btn-primary">Enable</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="disableModal" tabindex="-1" role="dialog"
+      aria-labelledby="disableModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Disable Auditing</h4>
+           </div>
+            <div class="modal-body">
+                <p>Are you sure you want to disable auditing for this permission?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default"
+                        data-dismiss="modal">Close</button>
+                <form action="/permissions/{{permission.name}}/disable-auditing" method="post"
+                      style="display: inline;">
+                    {{ xsrf_form() }}
+                    <button type="submit" class="btn btn-primary">Disable</button>
+                </form>
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -1166,7 +1166,7 @@ class Permission(Model):
     name = Column(String(length=64), unique=True, nullable=False)
     description = Column(Text, nullable=False)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
-    audited = Column(Boolean, default=False, nullable=False)
+    _audited = Column('audited', Boolean, default=False, nullable=False)
 
     @staticmethod
     def get(session, name=None):
@@ -1177,6 +1177,18 @@ class Permission(Model):
     @staticmethod
     def get_all(session):
         return session.query(Permission).order_by(asc("name")).all()
+
+    @property
+    def audited(self):
+        return self._audited
+
+    def enable_auditing(self):
+        self._audited = True
+        Counter.incr(self.session, "updates")
+
+    def disable_auditing(self):
+        self._audited = False
+        Counter.incr(self.session, "updates")
 
     def get_mapped_groups(self):
         '''

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -102,6 +102,6 @@ def permissions(session):
             session, name=permission, description="{} permission".format(permission))[0]
         for permission in ("ssh", "sudo", "audited", PERMISSION_AUDITOR)
     }
-    permissions["audited"].audited = True
+    permissions["audited"].enable_auditing()
     session.commit()
     return permissions


### PR DESCRIPTION
This adds a little more descriptive text for auditing so people can tell
when they're trying to join an audited group, and when a permission is
audited. This also puts an enable/disable button for permissions admins
so that we can turn the functionality on or off for a permission.