### PR TITLE
Add help_for method

### DIFF
--- a/grouper/fe/static/css/grouper.css
+++ b/grouper/fe/static/css/grouper.css
@@ -269,3 +269,15 @@ span.disabled {
 .account-link, .permission-link {
     white-space: nowrap;
 }
+
+.popover-content {
+    font-weight: normal;
+}
+
+.has-help {
+    border-bottom: 1px dotted #000;
+    text-decoration: none;
+}
+.account-link, .permission-link {
+    white-space: nowrap;
+}

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -3,4 +3,10 @@ $(document).ready(function(){
         $("#key-body").text($(this).attr("key-body"));
         $("#key-modal").modal('show');
     });
+
+    $('[data-toggle="popover"]').popover({
+        html: true,
+        placement: 'auto right',
+        container: 'body',
+    });
 });

--- a/grouper/fe/templates/forms/group-add.html
+++ b/grouper/fe/templates/forms/group-add.html
@@ -1,3 +1,5 @@
+{% from 'macros/ui.html' import help_for %}
+
 <div class="form-group {% if form.member.errors %}has-error{% endif %}">
     <label for="{{form.member.label.field_id}}"
            class="col-sm-3 control-label">
@@ -11,7 +13,7 @@
 <div class="form-group {% if form.role.errors %}has-error{% endif %}">
     <label for="{{form.role.label.field_id}}"
            class="col-sm-3 control-label">
-        {{ form.role.label.text }} {% if form.role.flags.required %}*{% endif %}
+        <span {{ help_for('role') }}>{{ form.role.label.text }}</span> {% if form.role.flags.required %}*{% endif %}
     </label>
     <div class="col-sm-7">
         {{ form.role(class_="form-control") }}

--- a/grouper/fe/templates/forms/group-join.html
+++ b/grouper/fe/templates/forms/group-join.html
@@ -1,3 +1,5 @@
+{% from 'macros/ui.html' import help_for %}
+
 <div class="form-group {% if form.member.errors %}has-error{% endif %}">
     <label for="{{form.member.label.field_id}}"
            class="col-sm-3 control-label">
@@ -11,7 +13,7 @@
 <div class="form-group {% if form.role.errors %}has-error{% endif %}">
     <label for="{{form.role.label.field_id}}"
            class="col-sm-3 control-label">
-        {{ form.role.label.text }} {% if form.role.flags.required %}*{% endif %}
+        <span {{ help_for('role') }}>{{ form.role.label.text }}</span> {% if form.role.flags.required %}*{% endif %}
     </label>
     <div class="col-sm-7">
         {{ form.role(class_="form-control") }}

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel %}
+{% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel,
+                                help_for %}
 
 {% block heading %}
     <a href="/groups">Groups</a>
@@ -59,7 +60,9 @@
         <h4>
             {% if audited %}
                 <span class="label label-warning pull-right">
-                    <i class="fa fa-gavel"></i> Auditing Enabled
+                    <i class="fa fa-gavel"></i> <span {{ help_for("audited_group") }}>
+                        Auditing Enabled
+                    </span>
                 </span>
             {% endif %}
             {% if group.canjoin == "canjoin" %}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -18,7 +18,7 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
-            <h3 class="panel-title">My Public Keys</h3>
+            <h3 class="panel-title">Public Keys</h3>
         </div>
         <div style="
             max-height: {{max_height}}px;
@@ -70,10 +70,26 @@
     </div>
 {%- endmacro %}
 
+{% macro help_for(subj) -%}
+class="has-help"
+data-toggle="popover"
+title="Grouper Help" data-content="
+{% if subj == "role" %}
+A 'role' describes someone's ability to control the group. There are three types of roles:
+<ul><li><strong>member</strong> has no special power</li>
+<li><strong>manager</strong> is allowed to process requests to join the group</li>
+<li><strong>owner</strong> has full control of the group</li></ul>
+{% elif subj == "audited_group" %}
+One or more of the permissions that apply to this group have auditing
+enabled. Membership in this group is regularly reviewed.
+{% endif %}
+"
+{%- endmacro %}
+
 {% macro group_panel(max_height, groups, show_role=False) -%}
     <div class="panel panel-default">
         <div class="panel-heading">
-            <h3 class="panel-title">My Groups</h3>
+            <h3 class="panel-title">Groups</h3>
         </div>
         <div style="
             max-height: {{max_height}}px;
@@ -85,7 +101,9 @@
                     <tr>
                         <th class="col-sm-2">Name</th>
                         {% if show_role %}
-                            <th class="col-sm-2">Role</th>
+                            <th class="col-sm-2">
+                                <span {{ help_for('role') }}>Role</span>
+                            </th>
                         {% endif %}
                     </tr>
                 </thead>
@@ -167,7 +185,7 @@
                     <tr>
                         <th class="col-sm-1"></th>
                         <th class="col-sm-3">Member</th>
-                        <th class="col-sm-1">Role</th>
+                        <th class="col-sm-1"><span {{ help_for('role') }}>Role</span></th>
                         <th class="col-sm-1">Expires</th>
                     </tr>
                 </thead>
@@ -247,7 +265,7 @@
 {% macro permission_panel(max_height, mappings, group=None, can_grant=None) -%}
     <div class="panel panel-default">
         <div class="panel-heading">
-            <h3 class="panel-title">My Permissions</h3>
+            <h3 class="panel-title">Permissions</h3>
         </div>
         <div style="
             max-height: {{max_height}}px;


### PR DESCRIPTION
This adds the ability to insert in-page help. I've started by adding it
for the Role tag, and audited groups. We can expand this to add more
help for people as questions come up and whenever we think we might need
it.