### PR TITLE
Require a '.' in UI-created permissions.

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -31,6 +31,7 @@ RESERVED_NAMES = [
     r"^grouper",
     r"^admin",
     r"^test",
+    r"^[^.]*$",
 ]
 
 # Maximum length a name can be. This applies to user names and permission arguments.

--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -8,8 +8,8 @@ NAME_VALIDATION = r"(?P<name>[@\-\w\.]+)"
 NAME2_VALIDATION = r"(?P<name2>[@\-\w\.]+)"
 
 # Regexes for validating permission/argument names
-PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+)"
-PERMISSION_WILDCARD_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+(?:\.\*)?)"
+PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*\.(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+)"
+PERMISSION_WILDCARD_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*\.(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+(?:\.\*)?)"
 ARGUMENT_VALIDATION = r"(?P<argument>|\*|[\w=/.:-]+\*?)"
 
 # Global permission names to prevent stringly typed things

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -10,7 +10,6 @@ import re
 import sshpubkey
 
 from ..audit import can_join, UserNotAuditor
-from ..constants import RESERVED_NAMES
 from .forms import (
     GroupForm, GroupJoinForm, GroupAddForm, GroupRequestModifyForm, PublicKeyForm,
     PermissionCreateForm, PermissionGrantForm, GroupEditMemberForm,
@@ -20,7 +19,7 @@ from ..models import (
     GROUP_JOIN_CHOICES, REQUEST_STATUS_CHOICES, GROUP_EDGE_ROLES, OBJ_TYPES,
     get_user_or_group,
 )
-from .util import GrouperHandler, Alert
+from .util import GrouperHandler, Alert, test_reserved_names
 from ..util import matches_glob
 
 
@@ -133,11 +132,8 @@ class PermissionsCreate(GrouperHandler):
             if matches_glob(creatable, form.data["name"]):
                 allowed = True
 
-        for reserved in RESERVED_NAMES:
-            if re.match(reserved, form.data["name"]):
-                form.name.errors.append(
-                    "Permission names must not match the pattern: %s" % (reserved, )
-                )
+        for failure_message in test_reserved_names(form.data["name"]):
+            form.name.errors.append(failure_message)
 
         if not allowed:
             form.name.errors.append(

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -4,6 +4,7 @@ from ..constants import NAME_VALIDATION, NAME2_VALIDATION, PERMISSION_VALIDATION
 HANDLERS = [
     (r"/", handlers.Index),
     (r"/groups", handlers.GroupsView),
+    (r"/permissions/create", handlers.PermissionsCreate),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), handlers.PermissionView),
     (r"/permissions", handlers.PermissionsView),
     (
@@ -14,7 +15,6 @@ HANDLERS = [
         r"/permissions/{}/disable-auditing".format(PERMISSION_VALIDATION),
         handlers.PermissionDisableAuditing
     ),
-    (r"/permissions/create", handlers.PermissionsCreate),
     (r"/permissions/grant/{}".format(NAME_VALIDATION), handlers.PermissionsGrant),
     (
         r"/permissions/{}/revoke/(?P<mapping_id>[0-9]+)".format(PERMISSION_VALIDATION),

--- a/grouper/fe/templates/help.html
+++ b/grouper/fe/templates/help.html
@@ -10,13 +10,90 @@
 
 {% block content %}
 
-<!-- TODO(mildorf): make this more helpful...  -->
+<!-- TODO(mildorf): clean up the style here, it's not 1995. -->
+<!-- TODO(mildorf): keep this in sync with reality. -->
 
 <h3>What is Grouper?</h3>
-<p>This is a group membership and permission management platform. In other words, we are an
-authorization service you can use to answer such questions as: who's in what groups, and what
-permissions do they have?</p>
+<p>Grouper is a group membership and permission management platform. In other words, an
+authorization service you can use to answer such questions as: who's in what groups, and
+what permissions do they have? However, Grouper itself is just a system for permissions
+specfication. It's up to Grouper clients to actually implement things like access
+control.</p>
 
+<h3>How does group membership work?</h3>
+<p>Users and groups are the nodes of a directed acyclic graph.  The users are always leaf
+nodes and are members of all of their ancestor groups.  Groups must always have at least
+one user child and can have any number of other groups as additional children, provided
+that the graph remains acyclic.</p>
+
+<h3>What's the difference between the member, manager, and owner roles?</h3>
+<p>These are the three types of group membership for users: a member just inherits the
+group's permissions, a manager is allowed to process requests to join a group, and an
+owner has full control over the group (including the ability to change the membership type
+of other users or add/remove the group's permissions.)  Technically, groups are members of
+other groups.</p>
+
+<h3>What's the deal with permissions?</h3>
+<!-- FIXME(mildorf): is the comment about whitespace correct? -->
+<p>Grouper permissions are just enumerated strings. First, permissions are first created
+(any string without whitespace can be added to the set of available permissions.) Then
+permissions are granted to groups as (permission, argument) pairs where an argument is an
+optional second string. Finally, users inherit the union of all (permission, argument)
+pairs from the groups of which they are members.</p>
+
+<h3>Who can create groups?</h3>
+<p>Everyone.  The user creating a group automatically becomes an owner of that group,
+which begins with no permissions.</p>
+
+<h3>Who can create users?</h3>
+<!-- TODO: update language once users can be prepopulated. -->
+<p>Users are automatically populated into Grouper as they visit the web UI.  We're working
+on a manual way to pre-populate users (see user_admin below).</p>
+
+<h3>Who can create permissions?</h3>
+<p>A user with the permission (grouper.permission.create, prefix.*) can create any
+permission starting with "prefix." (We recommend namespacing using the character '.' as a
+separator.)</p>
+
+<h3>Who can grant permissions?</h3>
+<p>Generally, a user with the permission (grouper.permission.grant, prefix.*) can grant
+any permission starting with "prefix." with any argument.  As a special case, the
+permission (grouper.permission.grant, grouper.permission.grant/prefix.*) allows a user to
+grant the permission to grant (grouper.permission.grant, prefix.*).</p>
+
+<h3>How does auditing work?</h3>
+<!-- FIXME(mildorf): does the argument matter for grouper.auditor.permission? -->
+<p>Grouper permissions have a bit that defines whether they are audited or not.  Groups
+with at least one audited permission become audited groups.  Users with the
+grouper.permission.auditor permission are auditors, and only auditors can be the manager
+or owner of an audited group.</p>
+
+<!-- TODO: change once auditing tooling is ready! -->
+<p>We're working on tooling to facilitate regular monitoring of both members of audited
+groups and groups with audited permissions.</p>
+
+<h3>How do I set up Grouper?</h3>
+<p>See the README that comes with Grouper. Basically, after a pip install, you need to
+configure grouper to find a SQL-style backing database and stand up processes to serve the
+read-write web UI and read-only programmatic API.</p>
+
+<h3>How do I set up the first groups and permissions?</h3>
+<p>There are three administrative flags, corresponding to global permission to administer
+  groups, users, and permissions, which can be set for any account. These grant powers
+  independent of the usual graph-based way and are given out manually via the following
+  commands:</p>
+
+<ul><li>bin/grouper-ctl -c config/dev.yaml -vv capabilities add user@example.com group_admin</li>
+<li>bin/grouper-ctl -c config/dev.yaml -vv capabilities add user@example.com user_admin</li>
+<li>bin/grouper-ctl -c config/dev.yaml -vv capabilities add user@example.com permission_admin</li></ul>
+
+<p>A group_admin has the power to manipulate the graph structure at will.  For example,
+they can create any group, add any user to any group as any role, provided that auditing
+requirements aren't violated.  A user_admin has the power to disable/enable a user account
+but no special power with respect to group membership. Finally, a permission_admin has the
+power to create any permission.</p>
+
+<h3>What if my questions aren't answered here?</h3>
 <p>There haven't been many frequently asked questions yet, so this hasn't been filled out
 yet! Please see the admins of this site for help and links to any documentation that they
 might have already filled out.</p>

--- a/grouper/fe/templates/help.html
+++ b/grouper/fe/templates/help.html
@@ -10,90 +10,13 @@
 
 {% block content %}
 
-<!-- TODO(mildorf): clean up the style here, it's not 1995. -->
-<!-- TODO(mildorf): keep this in sync with reality. -->
+<!-- TODO(mildorf): make this more helpful...  -->
 
 <h3>What is Grouper?</h3>
-<p>Grouper is a group membership and permission management platform. In other words, an
-authorization service you can use to answer such questions as: who's in what groups, and
-what permissions do they have? However, Grouper itself is just a system for permissions
-specfication. It's up to Grouper clients to actually implement things like access
-control.</p>
+<p>This is a group membership and permission management platform. In other words, we are an
+authorization service you can use to answer such questions as: who's in what groups, and what
+permissions do they have?</p>
 
-<h3>How does group membership work?</h3>
-<p>Users and groups are the nodes of a directed acyclic graph.  The users are always leaf
-nodes and are members of all of their ancestor groups.  Groups must always have at least
-one user child and can have any number of other groups as additional children, provided
-that the graph remains acyclic.</p>
-
-<h3>What's the difference between the member, manager, and owner roles?</h3>
-<p>These are the three types of group membership for users: a member just inherits the
-group's permissions, a manager is allowed to process requests to join a group, and an
-owner has full control over the group (including the ability to change the membership type
-of other users or add/remove the group's permissions.)  Technically, groups are members of
-other groups.</p>
-
-<h3>What's the deal with permissions?</h3>
-<!-- FIXME(mildorf): is the comment about whitespace correct? -->
-<p>Grouper permissions are just enumerated strings. First, permissions are first created
-(any string without whitespace can be added to the set of available permissions.) Then
-permissions are granted to groups as (permission, argument) pairs where an argument is an
-optional second string. Finally, users inherit the union of all (permission, argument)
-pairs from the groups of which they are members.</p>
-
-<h3>Who can create groups?</h3>
-<p>Everyone.  The user creating a group automatically becomes an owner of that group,
-which begins with no permissions.</p>
-
-<h3>Who can create users?</h3>
-<!-- TODO: update language once users can be prepopulated. -->
-<p>Users are automatically populated into Grouper as they visit the web UI.  We're working
-on a manual way to pre-populate users (see user_admin below).</p>
-
-<h3>Who can create permissions?</h3>
-<p>A user with the permission (grouper.permission.create, prefix.*) can create any
-permission starting with "prefix." (We recommend namespacing using the character '.' as a
-separator.)</p>
-
-<h3>Who can grant permissions?</h3>
-<p>Generally, a user with the permission (grouper.permission.grant, prefix.*) can grant
-any permission starting with "prefix." with any argument.  As a special case, the
-permission (grouper.permission.grant, grouper.permission.grant/prefix.*) allows a user to
-grant the permission to grant (grouper.permission.grant, prefix.*).</p>
-
-<h3>How does auditing work?</h3>
-<!-- FIXME(mildorf): does the argument matter for grouper.auditor.permission? -->
-<p>Grouper permissions have a bit that defines whether they are audited or not.  Groups
-with at least one audited permission become audited groups.  Users with the
-grouper.permission.auditor permission are auditors, and only auditors can be the manager
-or owner of an audited group.</p>
-
-<!-- TODO: change once auditing tooling is ready! -->
-<p>We're working on tooling to facilitate regular monitoring of both members of audited
-groups and groups with audited permissions.</p>
-
-<h3>How do I set up Grouper?</h3>
-<p>See the README that comes with Grouper. Basically, after a pip install, you need to
-configure grouper to find a SQL-style backing database and stand up processes to serve the
-read-write web UI and read-only programmatic API.</p>
-
-<h3>How do I set up the first groups and permissions?</h3>
-<p>There are three administrative flags, corresponding to global permission to administer
-  groups, users, and permissions, which can be set for any account. These grant powers
-  independent of the usual graph-based way and are given out manually via the following
-  commands:</p>
-
-<ul><li>bin/grouper-ctl -c config/dev.yaml -vv capabilities add user@example.com group_admin</li>
-<li>bin/grouper-ctl -c config/dev.yaml -vv capabilities add user@example.com user_admin</li>
-<li>bin/grouper-ctl -c config/dev.yaml -vv capabilities add user@example.com permission_admin</li></ul>
-
-<p>A group_admin has the power to manipulate the graph structure at will.  For example,
-they can create any group, add any user to any group as any role, provided that auditing
-requirements aren't violated.  A user_admin has the power to disable/enable a user account
-but no special power with respect to group membership. Finally, a permission_admin has the
-power to create any permission.</p>
-
-<h3>What if my questions aren't answered here?</h3>
 <p>There haven't been many frequently asked questions yet, so this hasn't been filled out
 yet! Please see the admins of this site for help and links to any documentation that they
 might have already filled out.</p>

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -241,7 +241,7 @@ def get_template_env(package="grouper.fe", extra_filters=None, extra_globals=Non
     return env
 
 
-# Returns a list of strings explaining whcih reserved regexes match a proposed
+# Returns a list of strings explaining which reserved regexes match a proposed
 # permission name.
 def test_reserved_names(permission_name):
     failure_messages = []

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -13,6 +13,7 @@ import traceback
 import urllib
 
 from .settings import settings
+from ..constants import RESERVED_NAMES
 from ..graph import Graph
 from ..models import User, GROUP_EDGE_ROLES, OBJ_TYPES_IDX, get_db_engine, Session
 from ..util import get_database_url
@@ -238,3 +239,15 @@ def get_template_env(package="grouper.fe", extra_filters=None, extra_globals=Non
     env.globals.update(j_globals)
 
     return env
+
+
+# Returns a list of strings explaining whcih reserved regexes match a proposed
+# permission name.
+def test_reserved_names(permission_name):
+    failure_messages = []
+    for reserved in RESERVED_NAMES:
+        if re.match(reserved, permission_name):
+            failure_messages.append(
+                "Permission names must not match the pattern: %s" % (reserved, )
+            )
+    return failure_messages

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,3 +1,7 @@
+import unittest
+
+import grouper.fe.util
+
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
 from util import get_group_permissions, get_user_permissions
 
@@ -23,3 +27,10 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
     assert sorted(get_user_permissions(graph, "zorkian")) == [
         "audited:", PERMISSION_AUDITOR + ":", "ssh:*", "sudo:shell"]
     assert sorted(get_user_permissions(graph, "testuser")) == []
+
+class PermissionTests(unittest.TestCase):
+    def test_reject_bad_permission_names(self):
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("permission_lacks_period")), 1)
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("grouper.prefix.reserved")), 1)
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("admin.prefix.reserved")), 1)
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("test.prefix.reserved")), 1)


### PR DESCRIPTION
Bugfix for the fight over /permissions/create by requiring some namespacing.