### PR TITLE
Require a '.' in UI-created permissions.

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -31,6 +31,7 @@ RESERVED_NAMES = [
     r"^grouper",
     r"^admin",
     r"^test",
+    r"^[^.]*$",
 ]
 
 # Maximum length a name can be. This applies to user names and permission arguments.

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -10,7 +10,6 @@ import re
 import sshpubkey
 
 from ..audit import can_join, UserNotAuditor
-from ..constants import RESERVED_NAMES
 from .forms import (
     GroupForm, GroupJoinForm, GroupAddForm, GroupRequestModifyForm, PublicKeyForm,
     PermissionCreateForm, PermissionGrantForm, GroupEditMemberForm,
@@ -20,7 +19,7 @@ from ..models import (
     GROUP_JOIN_CHOICES, REQUEST_STATUS_CHOICES, GROUP_EDGE_ROLES, OBJ_TYPES,
     get_user_or_group,
 )
-from .util import GrouperHandler, Alert
+from .util import GrouperHandler, Alert, test_reserved_names
 from ..util import matches_glob
 
 
@@ -133,11 +132,8 @@ class PermissionsCreate(GrouperHandler):
             if matches_glob(creatable, form.data["name"]):
                 allowed = True
 
-        for reserved in RESERVED_NAMES:
-            if re.match(reserved, form.data["name"]):
-                form.name.errors.append(
-                    "Permission names must not match the pattern: %s" % (reserved, )
-                )
+        for failure_message in test_reserved_names(form.data["name"]):
+            form.name.errors.append(failure_message)
 
         if not allowed:
             form.name.errors.append(

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -13,6 +13,7 @@ import traceback
 import urllib
 
 from .settings import settings
+from ..constants import RESERVED_NAMES
 from ..graph import Graph
 from ..models import User, GROUP_EDGE_ROLES, OBJ_TYPES_IDX, get_db_engine, Session
 from ..util import get_database_url
@@ -238,3 +239,15 @@ def get_template_env(package="grouper.fe", extra_filters=None, extra_globals=Non
     env.globals.update(j_globals)
 
     return env
+
+
+# Returns a list of strings explaining which reserved regexes match a proposed
+# permission name.
+def test_reserved_names(permission_name):
+    failure_messages = []
+    for reserved in RESERVED_NAMES:
+        if re.match(reserved, permission_name):
+            failure_messages.append(
+                "Permission names must not match the pattern: %s" % (reserved, )
+            )
+    return failure_messages

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,3 +1,7 @@
+import unittest
+
+import grouper.fe.util
+
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
 from util import get_group_permissions, get_user_permissions
 
@@ -23,3 +27,10 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
     assert sorted(get_user_permissions(graph, "zorkian")) == [
         "audited:", PERMISSION_AUDITOR + ":", "ssh:*", "sudo:shell"]
     assert sorted(get_user_permissions(graph, "testuser")) == []
+
+class PermissionTests(unittest.TestCase):
+    def test_reject_bad_permission_names(self):
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("permission_lacks_period")), 1)
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("grouper.prefix.reserved")), 1)
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("admin.prefix.reserved")), 1)
+        self.assertEquals(len(grouper.fe.util.test_reserved_names("test.prefix.reserved")), 1)


### PR DESCRIPTION
Add r"^[^.]*$" to the list of reserved names to block UI-created permissions that lack a period because namespacing is good.  Also add some unit tests.