### PR TITLE
Fix revoke button

### DIFF
--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -300,7 +300,7 @@ enabled. Membership in this group is regularly reviewed.
                             {% if map.distance == 0 %}
                             {% for grantable in can_grant if grantable[0].name == map.permission %}
                                 {% if loop.first %}
-                                    <a class="btn btn-default btn-xs" href="/permissions/{{ map.name }}/revoke/{{ map.mapping_id }}">
+                                    <a class="btn btn-default btn-xs" href="/permissions/{{ map.permission }}/revoke/{{ map.mapping_id }}">
                                     <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span> Revoke
                                     </a>
                                 {% endif %}


### PR DESCRIPTION
When we switched to using the graph, we lost the mapping_id for the
mapped permission, which is required to revoke. This fixes the UI to
make it possible to revoke permissions again.