### PR TITLE
Make permission granting check audited owners

### DIFF
--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -25,7 +25,49 @@ def user_is_auditor(username):
     return False
 
 
-def can_join(group, user_or_group, role="member"):
+def assert_controllers_are_auditors(group):
+    """Return whether not all owners/managers in a group (and below) are auditors
+
+    This is used to ensure that all of the people who can control a group (owners, managers)
+    and all subgroups (all the way down the tree) have audit permissions.
+
+    Raises:
+        UserNotAuditor: If a user is found that violates the audit training policy, then this
+            exception is raised.
+
+    Returns:
+        bool: True if the tree is completely controlled by auditors, else it will raise as above.
+    """
+    graph = Graph()
+    checked, queue = set(), [group.name]
+    while queue:
+        cur_group = queue.pop()
+        if cur_group in checked:
+            continue
+        details = graph.get_group_details(cur_group)
+        for chk_user, info in details["users"].iteritems():
+            if chk_user in checked:
+                continue
+            # Only examine direct members of this group, because then the role is accurate.
+            if info["distance"] == 1:
+                if info["rolename"] == "member":
+                    continue
+                if user_is_auditor(chk_user):
+                    checked.add(chk_user)
+                else:
+                    raise UserNotAuditor(
+                        "User {} has role {} of the {} group, but is not an auditor.".format(
+                            chk_user, info["rolename"], cur_group))
+        # Now put subgroups into the queue to examine.
+        for chk_group, info in details["subgroups"].iteritems():
+            if info["distance"] == 1:
+                queue.append(chk_group)
+
+    # If we didn't raise, we're valid.
+    return True
+
+
+def assert_can_join(group, user_or_group, role="member"):
     """Enforce audit rules on joining a group
 
     This applies the auditing rules to determine whether or not a given user can join the given
@@ -36,8 +78,12 @@ def can_join(group, user_or_group, role="member"):
         user (models.User): The user attempting to join.
         role (str): The role being tested.
 
+    Raises:
+        UserNotAuditor: If a user is found that violates the audit training policy, then this
+            exception is raised.
+
     Returns:
-        bool: True if the user should be allowed per policy, False if not.
+        bool: True if the user should be allowed per policy, else it will raise as above.
     """
     # By definition, any user can join as a member to any group.
     if user_or_group.type == "User" and role == "member":
@@ -64,29 +110,4 @@ def can_join(group, user_or_group, role="member"):
     #
     # We have to fetch each group's details individually though to figure out what someone's role
     # is in that particular group.
-    checked, queue = set(), [user_or_group.name]
-    while queue:
-        cur_group = queue.pop()
-        if cur_group in checked:
-            continue
-        details = graph.get_group_details(cur_group)
-        for chk_user, info in details["users"].iteritems():
-            if chk_user in checked:
-                continue
-            # Only examine direct members of this group, because then the role is accurate.
-            if info["distance"] == 1:
-                if info["rolename"] == "member":
-                    continue
-                if user_is_auditor(chk_user):
-                    checked.add(chk_user)
-                else:
-                    raise UserNotAuditor(
-                        "User {} is a {} of the {} group, but is not an auditor.".format(
-                            chk_user, info["rolename"], cur_group))
-        # Now put subgroups into the queue to examine.
-        for chk_group, info in details["subgroups"].iteritems():
-            if info["distance"] == 1:
-                queue.append(chk_group)
-
-    # No case failed, so we allow this action.
-    return True
+    return assert_controllers_are_auditors(user_or_group)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -2,7 +2,9 @@ import pytest
 
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
 
-from grouper.audit import can_join, user_is_auditor, UserNotAuditor
+from grouper.audit import (
+    assert_controllers_are_auditors, assert_can_join, user_is_auditor, UserNotAuditor
+)
 
 
 def test_group_audited(standard_graph, session, groups, permissions):  # noqa
@@ -23,34 +25,43 @@ def test_user_is_auditor(standard_graph):  # noqa
     assert not user_is_auditor("oliver")
 
 
-def test_can_join(standard_graph, session, users, groups, permissions):  # noqa
+def test_assert_can_join(users, groups):  # noqa
     """ Test various audit constraints to ensure that users can/can't join as appropriate. """
 
-    graph = standard_graph  # noqa
-
     # Non-auditor can join non-audited group as owner.
-    assert can_join(groups["team-infra"], users["zay"], role="owner")
+    assert assert_can_join(groups["team-infra"], users["zay"], role="owner")
 
     # Auditor can join non-audited group as owner.
-    assert can_join(groups["team-infra"], users["zorkian"], role="owner")
+    assert assert_can_join(groups["team-infra"], users["zorkian"], role="owner")
 
     # Non-auditor can NOT join audited group as owner.
     with pytest.raises(UserNotAuditor):
-        assert not can_join(groups["serving-team"], users["zay"], role="owner")
+        assert not assert_can_join(groups["serving-team"], users["zay"], role="owner")
 
     # Non-auditor can join audited group as member.
-    assert can_join(groups["serving-team"], users["zay"])
+    assert assert_can_join(groups["serving-team"], users["zay"])
 
     # Group with non-auditor owner can NOT join audited group.
     with pytest.raises(UserNotAuditor):
-        assert not can_join(groups["serving-team"], groups["tech-ops"])
+        assert not assert_can_join(groups["serving-team"], groups["tech-ops"])
 
     # Group with auditor owner can join audited group.
-    assert can_join(groups["serving-team"], groups["sad-team"])
+    assert assert_can_join(groups["serving-team"], groups["sad-team"])
 
     # Group with non-auditor owner can join non-audited group.
-    assert can_join(groups["team-infra"], groups["tech-ops"])
+    assert assert_can_join(groups["team-infra"], groups["tech-ops"])
 
     # Group with auditor owner, but sub-group with non-auditor owner, can NOT join audited group.
     with pytest.raises(UserNotAuditor):
-        assert not can_join(groups["audited-team"], groups["serving-team"])
+        assert not assert_can_join(groups["audited-team"], groups["serving-team"])
+
+
+def test_assert_controllers_are_auditors(groups):  # noqa
+    """ Test the method that determines if a subtree is controlled by auditors. """
+
+    # Group is safely controlled by auditors.
+    assert assert_controllers_are_auditors(groups["sad-team"])
+
+    # Group with non-auditor owner should fail this test.
+    with pytest.raises(UserNotAuditor):
+        assert not assert_controllers_are_auditors(groups["team-infra"])


### PR DESCRIPTION
This brings in the lgoic used to determine whether or not a group (and
all subgroups) are controlled by auditors into the permission granting
process. With this change, you can only grant an audited permission to a
group that is controlled entirely by auditors.