### PR TITLE
Fix infinite loop regex

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -8,8 +8,8 @@ NAME_VALIDATION = r"(?P<name>[@\-\w\.]+)"
 NAME2_VALIDATION = r"(?P<name2>[@\-\w\.]+)"
 
 # Regexes for validating permission/argument names
-PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+)"
-PERMISSION_WILDCARD_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+(?:\.\*)?)"
+PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.])*[a-z0-9]+)"
+PERMISSION_WILDCARD_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.])*[a-z0-9]+(?:\.\*)?)"
 ARGUMENT_VALIDATION = r"(?P<argument>|\*|[\w=/.:-]+\*?)"
 
 # Global permission names to prevent stringly typed things

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 import grouper.fe.util
@@ -5,7 +6,7 @@ import grouper.fe.util
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
 from util import get_group_permissions, get_user_permissions
 
-from grouper.constants import PERMISSION_AUDITOR
+from grouper.constants import PERMISSION_AUDITOR, PERMISSION_VALIDATION
 
 
 def test_basic_permission(standard_graph, session, users, groups, permissions):  # noqa
@@ -28,9 +29,20 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
         "audited:", PERMISSION_AUDITOR + ":", "ssh:*", "sudo:shell"]
     assert sorted(get_user_permissions(graph, "testuser")) == []
 
+
 class PermissionTests(unittest.TestCase):
     def test_reject_bad_permission_names(self):
         self.assertEquals(len(grouper.fe.util.test_reserved_names("permission_lacks_period")), 1)
         self.assertEquals(len(grouper.fe.util.test_reserved_names("grouper.prefix.reserved")), 1)
         self.assertEquals(len(grouper.fe.util.test_reserved_names("admin.prefix.reserved")), 1)
         self.assertEquals(len(grouper.fe.util.test_reserved_names("test.prefix.reserved")), 1)
+
+        def eval_permission(perm):
+            return re.match(r'^' + PERMISSION_VALIDATION + r'$', perm)
+
+        self.assertIsNotNone(eval_permission('foo.bar'))
+        self.assertIsNotNone(eval_permission('foobar'))
+        self.assertIsNotNone(eval_permission('foo.bar_baz'))
+        self.assertIsNone(eval_permission('foo__bar'))
+        self.assertIsNone(eval_permission('foo.bar.'))
+        self.assertIsNone(eval_permission('foo._bar'))


### PR DESCRIPTION
There was a bug in the regex that could allow accidental denials of
service when certain permissions were input.