### PR TITLE
First pass of implementing auditing

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -16,12 +16,16 @@ ARGUMENT_VALIDATION = r"(?P<argument>|\*|[\w=+/.:-]+\*?)"
 PERMISSION_GRANT = "grouper.permission.grant"
 PERMISSION_CREATE = "grouper.permission.create"
 PERMISSION_AUDITOR = "grouper.permission.auditor"
+AUDIT_MANAGER = "grouper.audit.manage"
+AUDIT_VIEWER = "grouper.audit.view"
 
 # Permissions that are always created and are reserved.
 SYSTEM_PERMISSIONS = [
     (PERMISSION_CREATE, "Ability to create permissions within Grouper."),
     (PERMISSION_GRANT, "Ability to grant a permission to a group."),
     (PERMISSION_AUDITOR, "Ability to own or manage groups with audited permissions."),
+    (AUDIT_MANAGER, "Ability to start global audits and view audit status."),
+    (AUDIT_VIEWER, "Ability to view audit results and status."),
 ]
 
 # A list of regular expressions that are reserved anywhere names are created. I.e., if a regex

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -94,6 +94,13 @@ class GroupEditForm(Form):
     ], default="canask")
 
 
+class AuditCreateForm(Form):
+    ends_at = TextField("Ends At", [
+        ValidateDate(),
+        validators.Required(),
+    ], id="audit-form-ends-at")
+
+
 class GroupRequestModifyForm(Form):
     status = SelectField("New Status", [
         validators.Required(),

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -1,28 +1,31 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import operator
 
 from expvar.stats import stats
 from tornado.web import RequestHandler
 
-from sqlalchemy import union_all, or_, and_
+from sqlalchemy import union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import label, literal
 
 import sshpubkey
 
 from ..audit import assert_controllers_are_auditors, assert_can_join, UserNotAuditor
-from ..constants import PERMISSION_GRANT, PERMISSION_CREATE, PERMISSION_AUDITOR
+from ..constants import (
+    PERMISSION_GRANT, PERMISSION_CREATE, PERMISSION_AUDITOR, AUDIT_MANAGER, AUDIT_VIEWER
+)
 
 from .forms import (
     GroupCreateForm, GroupEditForm, GroupJoinForm, GroupAddForm, GroupRemoveForm,
     GroupRequestModifyForm, PublicKeyForm, PermissionCreateForm,
-    PermissionGrantForm, GroupEditMemberForm,
+    PermissionGrantForm, GroupEditMemberForm, AuditCreateForm,
 )
 from ..graph import NoSuchUser, NoSuchGroup
 from ..models import (
     User, Group, Request, PublicKey, Permission, PermissionMap, AuditLog, GroupEdge, Counter,
     GROUP_JOIN_CHOICES, REQUEST_STATUS_CHOICES, GROUP_EDGE_ROLES, OBJ_TYPES,
-    get_all_groups, get_all_users, get_user_or_group,
+    get_all_groups, get_all_users,
+    get_user_or_group, Audit, AuditMember, AUDIT_STATUS_CHOICES,
 )
 from .settings import settings
 from .util import GrouperHandler, Alert, test_reserved_names
@@ -365,7 +368,7 @@ class PermissionsView(GrouperHandler):
     Controller for viewing the major permissions list. There is no privacy here; the existence of
     a permission is public.
     '''
-    def get(self):
+    def get(self, audited_only=False):
         offset = int(self.get_argument("offset", 0))
         limit = int(self.get_argument("limit", 100))
         audited_only = bool(int(self.get_argument("audited", 0)))
@@ -374,7 +377,7 @@ class PermissionsView(GrouperHandler):
 
         permissions = self.graph.get_permissions(audited=audited_only)
         total = len(permissions)
-        permissions = permissions[offset:offset+limit]
+        permissions = permissions[offset:offset + limit]
 
         can_create = self.current_user.my_creatable_permissions()
 
@@ -502,6 +505,7 @@ class GroupView(GrouperHandler):
             "group.html", group=group, members=members, groups=groups,
             num_pending=num_pending, alerts=alerts, permissions=permissions,
             log_entries=log_entries, grantable=grantable, audited=audited,
+            statuses=AUDIT_STATUS_CHOICES,
         )
 
 
@@ -734,6 +738,201 @@ class GroupRequests(GrouperHandler):
         )
 
 
+class AuditsComplete(GrouperHandler):
+    def post(self, audit_id):
+        user = self.get_current_user()
+        if not user.has_permission(AUDIT_MANAGER):
+            return self.forbidden()
+
+        audit = self.session.query(Audit).filter(Audit.id == audit_id).one()
+        if audit.complete:
+            return self.redirect("/groups/{}".format(audit.group.name))
+
+        edges = {}
+        for argument in self.request.arguments:
+            if argument.startswith('audit_'):
+                edges[int(argument.split('_')[1])] = self.request.arguments[argument][0]
+
+        for member in audit.my_members():
+            if member.id in edges:
+                # You can only approve yourself (otherwise you can remove yourself
+                # from the group and leave it ownerless)
+                if member.member.id == user.id:
+                    member.status = "approved"
+                elif edges[member.id] in AUDIT_STATUS_CHOICES:
+                    member.status = edges[member.id]
+
+        self.session.commit()
+
+        # Now if it's completable (no pendings) then mark it complete, else redirect them
+        # to the group page.
+        if not audit.completable:
+            return self.redirect('/groups/{}'.format(audit.group.name))
+
+        # Complete audits have to be "enacted" now. This means anybody marked as remove has to
+        # be removed from the group now.
+        for member in audit.my_members():
+            if member.status == "remove":
+                audit.group.revoke_member(self.current_user, member.member,
+                                          "Revoked as part of audit.")
+                AuditLog.log(self.session, self.current_user.id, 'remove_member',
+                             'Removed membership in audit: {}'.format(member.member.name),
+                             on_group_id=audit.group.id)
+
+        audit.complete = True
+        self.session.commit()
+
+        # Now cancel pending emails
+        self.cancel_async_emails('audit-{}'.format(audit.group.id))
+
+        AuditLog.log(self.session, self.current_user.id, 'complete_audit',
+                     'Completed group audit.', on_group_id=audit.group.id)
+
+        return self.redirect('/groups/{}'.format(audit.group.name))
+
+
+class AuditsCreate(GrouperHandler):
+    def get(self):
+        user = self.get_current_user()
+        if not user.has_permission(AUDIT_MANAGER):
+            return self.forbidden()
+
+        self.render(
+            "audit-create.html", form=AuditCreateForm(),
+        )
+
+    def post(self):
+        form = AuditCreateForm(self.request.arguments)
+        if not form.validate():
+            return self.render(
+                "audit-create.html", form=form,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        user = self.get_current_user()
+        if not user.has_permission(AUDIT_MANAGER):
+            return self.forbidden()
+
+        # Step 1, detect if there are non-completed audits and fail if so.
+        open_audits = self.session.query(Audit).filter(
+            Audit.complete == False).all()
+        if open_audits:
+            raise Exception("Sorry, there are audits in progress.")
+        ends_at = datetime.strptime(form.data["ends_at"], "%m/%d/%Y")
+
+        # Step 2, find all audited groups and schedule audits for each.
+        audited_groups = []
+        for groupname in self.graph.groups:
+            if not self.graph.get_group_details(groupname)["audited"]:
+                continue
+            group = Group.get(self.session, name=groupname)
+            audit = Audit(
+                group_id=group.id,
+                ends_at=ends_at,
+            )
+            try:
+                audit.add(self.session)
+                self.session.flush()
+            except IntegrityError:
+                self.session.rollback()
+                raise Exception("Failed to start the audit. Please try again.")
+
+            # Update group with new audit
+            audited_groups.append(group)
+            group.audit_id = audit.id
+
+            # Step 3, now get all members of this group and set up audit rows for those edges.
+            for member in group.my_members().values():
+                auditmember = AuditMember(
+                    audit_id=audit.id, edge_id=member.edge_id
+                )
+                try:
+                    auditmember.add(self.session)
+                except IntegrityError:
+                    self.session.rollback()
+                    raise Exception("Failed to start the audit. Please try again.")
+
+        self.session.commit()
+
+        AuditLog.log(self.session, self.current_user.id, 'start_audit',
+                     'Started global audit.')
+
+        # Calculate schedule of emails, basically we send emails at various periods in advance
+        # of the end of the audit period.
+        schedule_times = []
+        not_before = datetime.utcnow() + timedelta(1)
+        for days_prior in (28, 21, 14, 7, 3, 1):
+            email_time = ends_at - timedelta(days_prior)
+            email_time.replace(hour=17, minute=0, second=0)
+            if email_time > not_before:
+                schedule_times.append((days_prior, email_time))
+
+        # Now send some emails. We do this separately/later to ensure that the audits are all
+        # created. Email notifications are sent multiple times if group audits are still
+        # outstanding.
+        for group in audited_groups:
+            mail_to = [
+                member.name
+                for member in group.my_users()
+                if GROUP_EDGE_ROLES[member.role] in ('owner')
+            ]
+
+            self.send_email(mail_to, 'Group Audit: {}'.format(group.name), 'audit_notice', {
+                "group": group.name,
+                "ends_at": ends_at,
+            })
+
+            for days_prior, email_time in schedule_times:
+                self.send_async_email(
+                    mail_to,
+                    'Group Audit: {} - {} day(s) left'.format(group.name, days_prior),
+                    'audit_notice_reminder',
+                    {
+                        "group": group.name,
+                        "ends_at": ends_at,
+                        "days_left": days_prior,
+                    },
+                    email_time,
+                    async_key='audit-{}'.format(group.id),
+                )
+
+        return self.redirect("/audits")
+
+
+class AuditsView(GrouperHandler):
+    def get(self):
+        user = self.get_current_user()
+        if not (user.has_permission(AUDIT_VIEWER) or user.has_permission(AUDIT_MANAGER)):
+            return self.forbidden()
+
+        offset = int(self.get_argument("offset", 0))
+        limit = int(self.get_argument("limit", 50))
+        if limit > 200:
+            limit = 200
+
+        audits = (
+            self.session.query(Audit)
+            .order_by(Audit.started_at)
+        )
+
+        open_filter = self.get_argument("filter", "Open Audits")
+        if open_filter == "Open Audits":
+            audits = audits.filter(Audit.complete == False)
+
+        open_audits = any([not audit.complete for audit in audits])
+        total = audits.count()
+        audits = audits.offset(offset).limit(limit).all()
+
+        open_audits = self.session.query(Audit).filter(
+            Audit.complete == False).all()
+        can_start = user.has_permission(AUDIT_MANAGER)
+
+        self.render(
+            "audits.html", audits=audits, filter=open_filter, can_start=can_start,
+            offset=offset, limit=limit, total=total, open_audits=open_audits,
+        )
+
+
 class GroupsView(GrouperHandler):
     def get(self):
         self.handle_refresh()
@@ -755,7 +954,7 @@ class GroupsView(GrouperHandler):
             groups = self.graph.get_groups(audited=False)
             directly_audited_groups = set()
         total = len(groups)
-        groups = groups[offset:offset+limit]
+        groups = groups[offset:offset + limit]
 
         form = GroupCreateForm()
 
@@ -874,6 +1073,16 @@ class GroupAdd(GrouperHandler):
             form.member.errors.append("User or group is already a member of this group.")
         elif group.name == member.name:
             form.member.errors.append("By definition, this group is a member of itself already.")
+
+        # Ensure this doesn't violate auditing constraints
+        fail_message = 'This join is denied with this role at this time.'
+        try:
+            user_can_join = assert_can_join(group, member, role=form.data["role"])
+        except UserNotAuditor as e:
+            user_can_join = False
+            fail_message = e
+        if not user_can_join:
+            form.member.errors.append(fail_message)
 
         if form.member.errors:
             return self.render(
@@ -1295,7 +1504,6 @@ class PublicKeyDelete(GrouperHandler):
             "changed_user": user.name,
             "action": "removed",
         })
-
 
         return self.redirect("/users/{}?refresh=yes".format(user.name))
 

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -3,6 +3,9 @@ from ..constants import NAME_VALIDATION, NAME2_VALIDATION, PERMISSION_VALIDATION
 
 HANDLERS = [
     (r"/", handlers.Index),
+    (r"/audits", handlers.AuditsView),
+    (r"/audits/(?P<audit_id>[0-9]+)/complete", handlers.AuditsComplete),
+    (r"/audits/create", handlers.AuditsCreate),
     (r"/groups", handlers.GroupsView),
     (r"/permissions/create", handlers.PermissionsCreate),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), handlers.PermissionView),

--- a/grouper/fe/templates/audit-create.html
+++ b/grouper/fe/templates/audit-create.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/audits">Audits</a>
+{% endblock %}
+
+{% block subheading %}
+    Start Global Audit
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Start Global Audit</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/audits/create">
+                    <p>Submitting this form will create a new global audit. This will start
+                    new reviews for all audited groups.</p>
+
+                    {% include "forms/audit.html" %}
+
+                    <p>Set the above date to be the due date for the audit. Users will receive
+                    email notifications immediately, and will periodically receive updates
+                    about the state of their groups and work they need to do.</p>
+
+                    <p><strong>ONLY DO THIS IF YOU ARE VERY SURE.</strong></p>
+                <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Yes, Start Global Audit</button>
+                    </div>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block script %}
+<script src="{{cdnjs_prefix}}/ajax/libs/bootstrap-datetimepicker/3.0.0/js/bootstrap-datetimepicker.min.js">
+</script>
+
+<script type="text/javascript">
+    $(function () {
+        $('#audit-form-ends-at').datetimepicker({
+            pickTime: false,
+            icons: {
+                time: "fa fa-clock-o",
+                date: "fa fa-calendar",
+                up: "fa fa-arrow-up",
+                down: "fa fa-arrow-down"
+            },
+            useCurrent: false,
+            minDate: moment(),
+        });
+    });
+</script>
+{% endblock %}

--- a/grouper/fe/templates/audits.html
+++ b/grouper/fe/templates/audits.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import account, paginator, dropdown with context %}
+
+{% block heading %}
+    Audits
+{% endblock %}
+
+{% block subheading %}
+    {{total}} audit(s)
+{% endblock %}
+
+{% block headingbuttons %}
+    {{ dropdown("filter", filter, ["Open Audits", "All Audits"])}}
+    {{ dropdown("limit", limit, [50, 100, 200]) }}
+    {{ paginator(offset, limit, total) }}
+    {% if not open_audits %}
+        {% if can_start %}
+            <a href="/audits/create" class="btn btn-success">
+                <i class="fa fa-plus"></i> Start Global Audit
+            </a>
+        {% endif %}
+    {% else %}
+        <a class="btn btn-danger">
+            <i class="fa fa-warning"></i> Global Audit In Progress
+        </a>
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    {% if not audits %}
+        There are no audits to view.
+    {% else %}
+        <div class="col-md-10 col-md-offset-1">
+            <table class="table table-elist">
+                <thead>
+                    <tr>
+                        <th class="col-sm-4">Group</th>
+                        <th class="col-sm-2">Started</th>
+                        <th class="col-sm-2">Ends</th>
+                        <th class="col-sm-1">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for audit in audits %}
+                    <tr>
+                        <td>{{ account(audit.group) }}</td>
+                        <td>{{ audit.started_at|print_date }}</td>
+                        <td>{% if audit.complete %}
+                            ---
+                        {% else %}
+                            {{ audit.ends_at|delta_str }}
+                        {% endif %}</td>
+                        <td>{% if audit.complete %}
+                            <span class="btn-xs btn-success">
+                                <i class="fa fa-check"></i> complete
+                            </span>
+                        {% else %}
+                            <span class="btn-xs btn-danger">
+                                <i class="fa fa-warning"></i> in progress
+                            </span>
+                        {% endif %}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}
+
+

--- a/grouper/fe/templates/email/audit_notice_html.tmpl
+++ b/grouper/fe/templates/email/audit_notice_html.tmpl
@@ -1,0 +1,16 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}Group Membership Audit{% endblock %}
+
+{% block content %}
+
+<p>The <strong>{{ group }}</strong> group is part of an ongoing audit. As you are an owner of this
+group, you must visit the management page and process the audit:</p>
+
+<p><a href="{{url}}/groups/{{group}}">Process the audit.</a></p>
+
+<p>This is due by <strong>{{ ends_at }}</strong>.</p>
+
+<p>Thank you for your prompt attention!</p>
+
+{% endblock %}

--- a/grouper/fe/templates/email/audit_notice_reminder_html.tmpl
+++ b/grouper/fe/templates/email/audit_notice_reminder_html.tmpl
@@ -1,0 +1,19 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}Group Membership Audit{% endblock %}
+
+{% block content %}
+
+<p><strong>This is a reminder, you have <u>{{days_left}}</u> day(s) left in the auditing period
+for your group.</strong></p>
+
+<p>The <strong>{{ group }}</strong> group is part of an ongoing audit. As you are an owner of this
+group, you must visit the management page and process the audit:</p>
+
+<p><a href="{{url}}/groups/{{group}}">Process the audit.</a></p>
+
+<p>This is due by <strong>{{ ends_at }}</strong>.</p>
+
+<p>Thank you for your prompt attention!</p>
+
+{% endblock %}

--- a/grouper/fe/templates/email/audit_notice_reminder_text.tmpl
+++ b/grouper/fe/templates/email/audit_notice_reminder_text.tmpl
@@ -1,0 +1,18 @@
+{% extends "email/base_text.tmpl" %}
+
+{% block subject %}Group Membership Audit{% endblock %}
+
+{% block content %}
+***
+This is a reminder, you have {{days_left}} day(s) left in the auditing period for your group.
+***
+
+The {{ group }} group is part of an ongoing audit. As you are an owner of this group, you must
+visit the management page and process the audit:
+
+    {{url}}/groups/{{group}}
+
+This is due by {{ ends_at }}.
+
+Thank you for your prompt attention!
+{% endblock %}

--- a/grouper/fe/templates/email/audit_notice_text.tmpl
+++ b/grouper/fe/templates/email/audit_notice_text.tmpl
@@ -1,0 +1,14 @@
+{% extends "email/base_text.tmpl" %}
+
+{% block subject %}Group Membership Audit{% endblock %}
+
+{% block content %}
+The {{ group }} group is part of an ongoing audit. As you are an owner of this group, you must
+visit the management page and process the audit:
+
+    {{url}}/groups/{{group}}
+
+This is due by {{ ends_at }}.
+
+Thank you for your prompt attention!
+{% endblock %}

--- a/grouper/fe/templates/email/audit_reminder_html.tmpl
+++ b/grouper/fe/templates/email/audit_reminder_html.tmpl
@@ -1,0 +1,17 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}Group Membership Audit (reminder){% endblock %}
+
+{% block content %}
+<p><strong>REMINDER!</strong></p>
+
+<p>The <strong>{{ group }}</strong> group is part of an ongoing audit. As you are an owner of this
+group, you must visit the management page and process the audit:</p>
+
+<p><a href="{{url}}/groups/{{group}}">Process the audit.</a></p>
+
+<p>This is due by <strong>{{ ends_at }}</strong>.</p>
+
+<p>Thank you for your prompt attention!</p>
+
+{% endblock %}

--- a/grouper/fe/templates/email/audit_reminder_text.tmpl
+++ b/grouper/fe/templates/email/audit_reminder_text.tmpl
@@ -1,0 +1,16 @@
+{% extends "email/base_text.tmpl" %}
+
+{% block subject %}Group Membership Audit (reminder){% endblock %}
+
+{% block content %}
+REMINDER:
+
+The {{ group }} group is part of an ongoing audit. As you are an owner of this group, you must
+visit the management page and process the audit:
+
+    {{url}}/groups/{{group}}
+
+This is due by {{ ends_at }}.
+
+Thank you for your prompt attention!
+{% endblock %}

--- a/grouper/fe/templates/forms/audit.html
+++ b/grouper/fe/templates/forms/audit.html
@@ -1,0 +1,11 @@
+<div class="form-group {% if form.ends_at.errors %}has-error{% endif %}">
+    <label for="{{form.ends_at.label.field_id}}"
+           class="col-sm-3 control-label">
+        {{ form.ends_at.label.text }} *
+    </label>
+    <div class="col-sm-7">
+        {{ form.ends_at(class_="form-control", placeholder="MM/DD/YYYY") }}
+    </div>
+</div>
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel,
-                                help_for %}
+                                help_for, account %}
 
 {% block heading %}
     <a href="/groups">Groups</a>
@@ -8,6 +8,9 @@
 
 {% block subheading %}
     {{group.groupname}} {% if not group.enabled %}<small>(disabled)</small>{% endif %}
+    {% if group.audit and not group.audit.complete %}
+        <span class="label label-danger">AUDIT IN PROGRESS</i>
+    {% endif %}
 {% endblock %}
 
 {% block headingbuttons %}
@@ -195,6 +198,71 @@
     </div>
 </div>
 
+{% if group.audit %}
+
+{% macro audit_status(member) -%}
+    {% if member.member.name == current_user.name %}
+        <input type="hidden" name="audit_{{member.id}}" value="approved" />
+        approved
+    {% else %}
+        <select name="audit_{{member.id}}">
+            {% for status in statuses %}
+            <option {% if status == member.status %}selected{% endif %}>{{ status }}</option>
+            {% endfor %}
+        </select>
+    {% endif %}
+{% endmacro %}
+
+<div class="modal fade" id="auditModal" tabindex="-1" role="dialog"
+      aria-labelledby="auditModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <form action="/audits/{{ group.audit.id }}/complete" method="post"
+              style="display: inline;">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Audit Group</h4>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Your group has an outstanding audit that needs to be completed before
+                    <strong>{{ group.audit.ends_at|print_date }}</strong>, giving you
+                    {{ group.audit.ends_at|delta_str }} to complete the audit.
+                </p>
+                <table class="table table-striped table-condensed">
+                    <thead>
+                        <tr>
+                            <th class="col-sm-4">Member</th>
+                            <th class="col-sm-2">Audit Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for member in group.audit.my_members() %}
+                        <tr>
+                            <td>{{ account(member.member) }}</a></td>
+                            <td>
+                                {{ audit_status(member) }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default"
+                        data-dismiss="modal">Close</button>
+                    {{ xsrf_form() }}
+                    <button type="submit" class="btn btn-primary">Complete Audit</button>
+            </div>
+        </div>
+        </form>
+    </div>
+</div>
+{% endif %}
+
 {% endblock %}
 
 {% block script %}
@@ -219,4 +287,11 @@ text and set its form actions to correspond to the selected user. #}
     });
 </script>
 
+{% if group.audit and not group.audit.complete and current_user.my_role(members) == "owner" %}
+<script type="text/javascript">
+$(function () {
+    $('#auditModal').modal('show');
+});
+</script>
+{% endif %}
 {% endblock %}

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -138,6 +138,20 @@ class GrouperHandler(tornado.web.RequestHandler):
         """
         return self.send_async_email(recipients, subject, template, context, datetime.utcnow())
 
+    def cancel_async_emails(self, async_key):
+        """Cancel pending async emails by key
+
+        If you scheduled an asynchronous email with an async_key previously, this method can be
+        used to cancel any unsent emails.
+
+        Args:
+            async_key (str): The async_key previously provided for your emails.
+        """
+        self.session.query(AsyncNotification).filter(
+            AsyncNotification.key == async_key,
+            AsyncNotification.sent == False
+        ).update({"sent": True})
+
     def send_async_email(self, recipients, subject, template, context, send_after, async_key=None):
         """Construct a message object from a template and schedule it
 
@@ -281,7 +295,8 @@ def delta_str(date_obj):
     return "Expired"
 
 
-def get_template_env(package="grouper.fe", deployment_name="", extra_filters=None, extra_globals=None):
+def get_template_env(package="grouper.fe", deployment_name="",
+                     extra_filters=None, extra_globals=None):
     filters = {
         "print_date": print_date,
         "delta_str": delta_str,

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -42,6 +42,8 @@ GROUP_JOIN_CHOICES = {
     "nobody": "<integrityerror>",
 }
 
+AUDIT_STATUS_CHOICES = {"pending", "approved", "remove"}
+
 REQUEST_STATUS_CHOICES = {
     # Request has been made and awaiting action.
     "pending": set(["actioned", "cancelled"]),
@@ -384,6 +386,29 @@ class User(Model):
 
         return AuditLog.get_entries(self.session, involve_user_id=self.id, limit=20)
 
+    def has_permission(self, permission, argument=None):
+        """See if this user has a given permission/argument
+
+        This walks a user's permissions (local/direct only) and determines if they have the given
+        permission. If an argument is specified, we validate if they have exactly that argument
+        or if they have the wildcard ('*') argument.
+
+        Args:
+            permission (str): Name of permission to check for.
+            argument (str, Optional): Name of argument to check for.
+
+        Returns:
+            bool: Whether or not this user fulfills the permission.
+        """
+        for perm in self.my_permissions():
+            if perm.name != permission:
+                continue
+            if perm.argument == '*' or argument is None:
+                return True
+            if perm.argument == argument:
+                return True
+        return False
+
     def my_permissions(self):
 
         # TODO: Make this walk the tree, so we can get a user's entire set of permissions.
@@ -518,6 +543,10 @@ class Group(Model):
     description = Column(Text)
     canjoin = Column(Enum(*GROUP_JOIN_CHOICES), default="canask")
     enabled = Column(Boolean, default=True, nullable=False)
+
+    audit_id = Column(Integer, nullable=True)
+    audit = relationship("Audit", foreign_keys=[audit_id],
+                         primaryjoin=lambda: Audit.id == Group.audit_id)
 
     @hybrid_property
     def name(self):
@@ -800,6 +829,7 @@ class Group(Model):
             label("type", literal("User")),
             label("name", user_member.username),
             label("role", GroupEdge._role),
+            label("edge_id", GroupEdge.id),
             label("expiration", GroupEdge.expiration)
         ).filter(
             parent.id == self.id,
@@ -822,6 +852,7 @@ class Group(Model):
             label("type", literal("Group")),
             label("name", group_member.groupname),
             label("role", GroupEdge._role),
+            label("edge_id", GroupEdge.id),
             label("expiration", GroupEdge.expiration)
         ).filter(
             parent.id == self.id,
@@ -838,7 +869,7 @@ class Group(Model):
         ).subquery()
 
         query = self.session.query(
-            "id", "type", "name", "role", "expiration"
+            "id", "type", "name", "role", "edge_id", "expiration"
         ).select_entity_from(
             union_all(users.select(), groups.select())
         ).order_by(
@@ -943,6 +974,100 @@ class Group(Model):
     def __repr__(self):
         return "<%s: id=%s groupname=%s>" % (
             type(self).__name__, self.id, self.groupname)
+
+
+class AuditMember(Model):
+    """An AuditMember is a single instantiation of a user in an audit
+
+    Tracks the status of the member within the audit. I.e., have they been reviewed, should they
+    be removed, etc.
+    """
+
+    __tablename__ = "audit_members"
+
+    id = Column(Integer, primary_key=True)
+
+    audit_id = Column(Integer, ForeignKey("audits.id"), nullable=False)
+    audit = relationship("Audit", backref="members", foreign_keys=[audit_id])
+
+    edge_id = Column(Integer, ForeignKey("group_edges.id"), nullable=False)
+    edge = relationship("GroupEdge", backref="audits", foreign_keys=[edge_id])
+
+    status = Column(Enum(*AUDIT_STATUS_CHOICES), default="pending", nullable=False)
+
+    @hybrid_property
+    def member(self):
+        if self.edge.member_type == 0:  # User
+            return User.get(self.session, pk=self.edge.member_pk)
+        elif self.edge.member_type == 1:  # Group
+            return Group.get(self.session, pk=self.edge.member_pk)
+        raise Exception("invalid member_type in AuditMember!")
+
+
+class Audit(Model):
+    """An Audit is applied to a group for a particular audit period
+
+    This contains all of the state of a given audit including each of the members who were
+    present in the group at the beginning of the audit period.
+    """
+
+    __tablename__ = "audits"
+
+    id = Column(Integer, primary_key=True)
+
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
+    group = relationship("Group", foreign_keys=[group_id])
+
+    # If this audit is complete and when it started/ended
+    complete = Column(Boolean, default=False, nullable=False)
+    started_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    ends_at = Column(DateTime, nullable=False)
+
+    # Tracks the last time we emailed the responsible parties of this audit
+    last_reminder_at = Column(DateTime, nullable=True)
+
+    def my_members(self):
+        """Return all members of this audit
+
+        Only currently valid members (haven't since left the group and haven't joined since the
+        audit started).
+
+        Returns:
+            list(AuditMember): the members of the audit.
+        """
+
+        # Get all members of the audit. Note that this list might change since people can
+        # join or leave the group.
+        auditmembers = self.session.query(AuditMember).filter(
+            AuditMember.audit_id == self.id
+        ).all()
+
+        edges = {}
+        for member in auditmembers:
+            edges[member.edge_id] = [member, False]
+
+        # Now get current members of the group. If someone has left the group, we don't include
+        # them in the audit anymore. If someone new joins (or rejoins) then we also don't want
+        # to audit them since they had to get approved into the group.
+        for member in self.group.my_members().values():
+            if member.edge_id in edges:
+                edges[member.edge_id][1] = True
+
+        # Now return the list of members.
+        return [member[0] for member in edges.values() if member[1]]
+
+    @property
+    def completable(self):
+        """Whether or not this audit is completable
+
+        This is defined as "when all members have been assigned a non-pending status". I.e., at
+        that point, we can hit the Complete button which will perform any actions necessary to
+        the membership.
+
+        Returns:
+            bool: Whether or not this audit can be marked as completed.
+        """
+        return all([member.status != "pending" for member in self.my_members()])
 
 
 class Request(Model):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 mrproxy==0.3.2
 py==1.4.20
-pytest==2.5.2
+pytest==2.7.2
+coverage==3.7.1

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -35,6 +35,22 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
         "sudo:shell"]
 
 
+def test_has_permission(standard_graph, users):  # noqa
+    """ Tests the has_permission method of a user object. """
+
+    # In our setup, zorkian has 'audited' with no arguments
+    assert users["zorkian"].has_permission("audited"), "zorkian has permission audited"
+    assert not users["zorkian"].has_permission("audited", argument='foo'), \
+        "zorkian has permission audited:foo"
+    assert not users["zorkian"].has_permission("audited", argument='*'), \
+        "zorkian has permission audited:*"
+
+    # zay has ssh:*
+    assert users["zay"].has_permission("ssh"), "zay has permission ssh"
+    assert users["zay"].has_permission("ssh", argument='foo'), "zay has permission ssh:foo"
+    assert users["zay"].has_permission("ssh", argument='*'), "zay has permission ssh:*"
+
+
 class PermissionTests(unittest.TestCase):
     def test_reject_bad_permission_names(self):
         self.assertEquals(len(grouper.fe.util.test_reserved_names("permission_lacks_period")), 1)


### PR DESCRIPTION
This creates an "audits" framework that allows someone to start a global
audit. When this is done we take a point in time snapshot of all the
members of all audited groups at that time and then set up an audit for
each group.

These audits are then displayed to group owners when they visit their
groups, and they're forced to go through a process whereby they
approve/remove everybody in their group.

Once done, they mark the audit as complete and the statuses are checked
and then enforced.