### PR TITLE
Support removing users from groups.

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -109,6 +109,19 @@ class GroupAddForm(Form):
     ], id="add-form-expiration")
 
 
+class GroupRemoveForm(Form):
+    member = TextField("Member", [
+        validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
+        validators.Required(),
+        ValidateRegex(constants.NAME_VALIDATION),
+    ])
+    member_type = SelectField("Member Type", [
+        validators.Required(),
+    ], choices=[
+        ("user", "User"), ("group", "Group"),
+    ])
+
+
 class GroupJoinForm(Form):
     member = SelectField("Member", [
         validators.Length(min=3, max=constants.MAX_NAME_LENGTH),

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -14,8 +14,9 @@ from ..audit import assert_controllers_are_auditors, assert_can_join, UserNotAud
 from ..constants import PERMISSION_GRANT, PERMISSION_CREATE, PERMISSION_AUDITOR
 
 from .forms import (
-    GroupForm, GroupJoinForm, GroupAddForm, GroupRequestModifyForm, PublicKeyForm,
-    PermissionCreateForm, PermissionGrantForm, GroupEditMemberForm,
+    GroupForm, GroupJoinForm, GroupAddForm, GroupRemoveForm,
+    GroupRequestModifyForm, PublicKeyForm, PermissionCreateForm,
+    PermissionGrantForm, GroupEditMemberForm,
 )
 from ..models import (
     User, Group, Request, PublicKey, Permission, PermissionMap, AuditLog, GroupEdge,
@@ -866,6 +867,40 @@ class GroupAdd(GrouperHandler):
                          member.name, form.data["role"]),
                      on_group_id=group.id)
 
+        return self.redirect("/groups/{}".format(group.name))
+
+
+class GroupRemove(GrouperHandler):
+    def post(self, group_id=None, name=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+
+        if not self.current_user.can_manage(group):
+            return self.forbidden()
+
+        form = GroupRemoveForm(self.request.arguments)
+        if not form.validate():
+            return self.send_error(status_code=400)
+
+        member_type, member_name = form.data["member_type"], form.data["member"]
+
+        members = group.my_members()
+        if not members.get((member_type.capitalize(), member_name), None):
+            return self.notfound()
+
+        removed_member = get_user_or_group(self.session, member_name, user_or_group=member_type)
+
+        if self.current_user == removed_member:
+            return self.send_error(
+                status_code=400,
+                reason="Can't remove yourself. Leave group instead."
+            )
+
+        group.revoke_member(self.current_user, removed_member, "Removed by owner/manager")
+        AuditLog.log(self.session, self.current_user.id, 'remove_from_group',
+                     '{} was removed from the group.'.format(removed_member.name),
+                     on_group_id=group.id)
         return self.redirect("/groups/{}".format(group.name))
 
 

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -44,6 +44,7 @@ for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):
         (r"/groups/{}/enable".format(regex), handlers.GroupEnable),
         (r"/groups/{}/join".format(regex), handlers.GroupJoin),
         (r"/groups/{}/add".format(regex), handlers.GroupAdd),
+        (r"/groups/{}/remove".format(regex), handlers.GroupRemove),
         (r"/groups/{}/leave".format(regex), handlers.GroupLeave),
         (r"/groups/{}/requests".format(regex), handlers.GroupRequests),
         (

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -154,4 +154,61 @@
     </div>
 </div>
 
+<div class="modal fade" id="removeUserModal" tabindex="-1" role="dialog"
+      aria-labelledby="removeUserModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Remove User</h4>
+           </div>
+            <div class="modal-body">
+                <p>
+                    Are you sure you want to remove <span class="member-name"></span> from {{group.name}}?
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default"
+                        data-dismiss="modal">Close</button>
+                <form class="remove-member-form"
+                      {# action is set dynamically in on("show.bs.modal") #}
+                      action="#" method="post"
+                      style="display: inline;">
+                    <input type="hidden" name="member"></input>
+                    <input type="hidden" name="member_type"></input>
+                    {{ xsrf_form() }}
+                    <button type="submit" class="btn btn-primary">Remove</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block script %}
+{# The removeUserModal is generated once per page but could be used for any
+member being removed. So, when the modal shows up, make sure to populate its
+text and set its form actions to correspond to the selected user. #}
+<script type="text/javascript">
+    $(function () {
+        $("#removeUserModal").on("show.bs.modal", function(e) {
+            var button = $(e.relatedTarget);
+            var memberName = button.data("member-name");
+            var memberType = button.data("member-type");
+
+            var modal = $(e.currentTarget);
+            modal.find(".member-name").html(memberName);
+
+            var form = modal.find(".remove-member-form")
+            form.attr("action", "/groups/{{ group.id }}/remove");
+            form.find("input[name=member]").val(memberName);
+            form.find("input[name=member_type]").val(memberType);
+        });
+    });
+</script>
+
 {% endblock %}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -160,6 +160,14 @@ enabled. Membership in this group is regularly reviewed.
                    class="btn btn-default btn-xs">
                     <i class="fa fa-edit"></i>
                 </a>
+
+                <button class="btn btn-danger btn-xs"
+                        data-toggle="modal"
+                        data-target="#removeUserModal"
+                        data-member-name="{{member.name}}"
+                        data-member-type="{{member.type|lower}}">
+                    <i class="fa fa-times"></i>
+                </a>
             {% endif %}
         </td>
         <td>

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -194,20 +194,28 @@ def get_all_users(session):
     return session.query(User).all()
 
 
-def get_user_or_group(session, name):
+def get_user_or_group(session, name, user_or_group=None):
     """Given a name, fetch a user or group
 
-    Since users are defined as being email addresess, we can easily tell which one the user is
-    trying to fetch. We try to get one or the other.
+    If user_or_group is not defined, we determine whether a the name refers to
+    a user or group by checking whether the name is an email address, since
+    that's how users are specified.
 
     Args:
         session (Session): Session to load data on.
         name (str): The name of the user or group.
+        user_or_group(str): "user" or "group" to specify the type explicitly
 
     Returns:
         User or Group object.
     """
-    if '@' in name:
+    if user_or_group is not None:
+        assert (user_or_group in ["user", "group"], "%s not in ['user', 'group']" % user_or_group)
+        is_user = (user_or_group == "user")
+    else:
+        is_user = '@' in name
+
+    if is_user:
         return session.query(User).filter_by(username=name).scalar()
     else:
         return session.query(Group).filter_by(groupname=name).scalar()


### PR DESCRIPTION
Added a 'remove' button next to the 'edit' button that removes a user
from a group via modal.

Users must be owners to remove members from groups. Users may not remove
themselves (use "leave group" instead).