### PR TITLE
Add /audited-permissions, /audited-groups.

### DIFF
--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -3,9 +3,11 @@ from ..constants import NAME_VALIDATION, NAME2_VALIDATION, PERMISSION_VALIDATION
 
 HANDLERS = [
     (r"/", handlers.Index),
+    (r"/audited-groups", handlers.AuditedGroupsView),
     (r"/groups", handlers.GroupsView),
     (r"/permissions/create", handlers.PermissionsCreate),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), handlers.PermissionView),
+    (r"/audited-permissions", handlers.AuditedPermissionsView),
     (r"/permissions", handlers.PermissionsView),
     (
         r"/permissions/{}/enable-auditing".format(PERMISSION_VALIDATION),

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -2,11 +2,18 @@
 {% from 'macros/ui.html' import account, paginator, dropdown with context %}
 
 {% block heading %}
+    {% if audited_groups %}
+      Audited
+    {% endif %}
     Groups
 {% endblock %}
 
 {% block subheading %}
-    {{total}} group(s)
+    {{total}}
+    {% if audited_groups %}
+      audited
+    {% endif %}
+    group(s)
 {% endblock %}
 
 {% block headingbuttons %}
@@ -15,6 +22,15 @@
     <button class="btn btn-success" data-toggle="modal" data-target="#createModal">
         <i class="fa fa-plus"></i> Create
     </button>
+    {% if audited_groups %}
+    <a class="btn btn-warning" href="/groups?limit={{limit}}">
+        <i class="fa"></i> Show all groups
+    </a>
+    {% else %}
+    <a class="btn btn-warning" href="/audited-groups?limit={{limit}}">
+        <i class="fa"></i> Show audited groups only
+    </a>
+    {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -25,6 +41,9 @@
                     <th class="col-sm-2">Groupname</th>
                     <th class="col-sm-4">Description</th>
                     <th class="col-sm-1">Can join?</th>
+		    {% if audited_groups %}
+		    <th class="col-sm-1">Why audited?</th>
+		    {% endif %}
                 </tr>
             </thead>
             <tbody>
@@ -39,6 +58,15 @@
                             Must Ask
                         {% endif %}
                     </td>
+		    {% if audited_groups %}
+		    <td>
+		      {% if group.groupname in directly_audited_groups %}
+		      Direct
+		      {% else %}
+		      Inherited
+		      {% endif %}
+		    </td>
+		    {% endif %}
                 </tr>
             {% endfor %}
             </tbody>

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -2,6 +2,9 @@
 {% from 'macros/ui.html' import permission, paginator, dropdown with context %}
 
 {% block heading %}
+    {% if audited_permissions %}
+      Audited
+    {% endif %}
     Permissions
 {% endblock %}
 
@@ -15,6 +18,15 @@
     {% if can_create %}
     <a class="btn btn-success" href="/permissions/create">
         <i class="fa fa-plus"></i> Create
+    </a>
+    {% endif %}
+    {% if audited_permissions %}
+    <a class="btn btn-warning" href="/permissions?limit={{limit}}">
+        <i class="fa"></i> Show all permissions
+    </a>
+    {% else %}
+    <a class="btn btn-warning" href="/audited-permissions?limit={{limit}}">
+        <i class="fa"></i> Show audited permissions only
     </a>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
This adds buttons to the /groups and /permissions pages that toggle between complete lists and audited-only lists; the audited-only lists are served at /audited-groups and /audited-permissions respectively.  This should help with scoping an audit.