### PR TITLE
Fix bug affecting startup.

### DIFF
--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -1,3 +1,5 @@
+# TODO(mildorf): we should refresh the graph after every write operation so that
+# redirects at the end of posts will include their effects.
 from datetime import datetime
 import operator
 

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -68,6 +68,10 @@ class GrouperHandler(tornado.web.RequestHandler):
             if created:
                 logging.info("Created new user %s", username)
                 self.session.commit()
+                # Because the graph doesn't initialize until the updates table
+                # is populated, we need to refresh the graph here in case this
+                # is the first update.
+                self.graph.update_from_db(self.session)
         except sqlalchemy.exc.OperationalError:
             # Failed to connect to database or create user, try to reconfigure the db. This invokes
             # the fetcher to try to see if our URL string has changed.


### PR DESCRIPTION
The Grouper UI sometimes 500s when because it goes looking for self._rgraph to serve a user's personal view before the graph has been initialized.  This is an easy way to fix that.