### PR TITLE
Make it possible to distinguish grouper FE deployments.

### DIFF
--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -68,6 +68,8 @@ def main(argv):
                         help="Display version information.")
     parser.add_argument("-p", "--port", type=int, default=None,
                         help="Override port in config.")
+    parser.add_argument("-n", "--deployment-name", type=str, default="",
+                        help="Name of the deployment.")
 
     args = parser.parse_args()
     settings.update_from_config(args.config, "fe")
@@ -97,7 +99,7 @@ def main(argv):
         "xsrf_cookies": True,
     }
 
-    template_env = get_template_env()
+    template_env = get_template_env(deployment_name=args.deployment_name)
 
     Session.configure(bind=get_db_engine(get_database_url(settings)))
 

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -25,7 +25,7 @@
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                     <span class="fa fa-gear"></span>
                 </button>
-                <a class="navbar-brand" href="/" class="{{is_active('/')}}"><span>GROUPER.</span></a>
+                <a class="navbar-brand" href="/" class="{{is_active('/')}}"><span>GROUPER.{{deployment_name}}</span></a>
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -274,13 +274,14 @@ def delta_str(date_obj):
     return "Expired"
 
 
-def get_template_env(package="grouper.fe", extra_filters=None, extra_globals=None):
+def get_template_env(package="grouper.fe", deployment_name="", extra_filters=None, extra_globals=None):
     filters = {
         "print_date": print_date,
         "delta_str": delta_str,
     }
     j_globals = {
         "cdnjs_prefix": settings["cdnjs_prefix"],
+        "deployment_name": deployment_name,
         "ROLES": GROUP_EDGE_ROLES,
         "TYPES": OBJ_TYPES_IDX,
     }


### PR DESCRIPTION
By adding an option to the grouper-fe executable, we make it possible to distinguish the deployments (e.g. "canary") serving the UI without any dependence on routing strategies.