### PR TITLE
Allow for non-technical owners, fix manager add choices.

### DIFF
--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -26,9 +26,9 @@ def user_is_auditor(username):
 
 
 def assert_controllers_are_auditors(group):
-    """Return whether not all owners/managers in a group (and below) are auditors
+    """Return whether not all owners/np-owners/managers in a group (and below) are auditors
 
-    This is used to ensure that all of the people who can control a group (owners, managers)
+    This is used to ensure that all of the people who can control a group (owners, np-owners, managers)
     and all subgroups (all the way down the tree) have audit permissions.
 
     Raises:
@@ -105,8 +105,8 @@ def assert_can_join(group, user_or_group, role="member"):
                 user_or_group.name))
 
     # No, this is a group-joining-group case. In this situation we must walk the entire group
-    # subtree and ensure that all owners/managers are considered auditors. This data is contained
-    # in the group metadetails, which contains all eventual members.
+    # subtree and ensure that all owners/np-owners/managers are considered auditors. This data
+    # is contained in the group metadetails, which contains all eventual members.
     #
     # We have to fetch each group's details individually though to figure out what someone's role
     # is in that particular group.

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -97,9 +97,6 @@ class GroupAddForm(Form):
     role = SelectField("Role", [
         validators.Length(min=3, max=32),
         validators.Required(),
-    ], choices=[
-        (role, role.title())
-        for role in models.GROUP_EDGE_ROLES
     ], default="member")
     reason = TextAreaField("Reason", [
         validators.Required(),

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -39,7 +39,7 @@
 {% else %}
     <div class="col-md-8 col-md-offset-2">
         <div class="alert alert-danger" role="alert">
-            You and all Groups you are a manager/owner of are already members of
+            You and all Groups you are a manager/owner/np-owner of are already members of
             the <em>{{group.name}}</em> Group. You can modify memberships from the member
             list <a href="/groups/{{group.name}}">here</a>.
         </div>

--- a/grouper/fe/templates/group-requests.html
+++ b/grouper/fe/templates/group-requests.html
@@ -21,7 +21,7 @@
         <table class="table table-elist">
             <thead>
                 <tr>
-                    {% if current_user.my_role(members) in ("manager", "owner") %}
+                    {% if current_user.my_role(members) in ("manager", "owner", "np-owner") %}
                         <th class="col-sm-1">Modify</th>
                     {% endif %}
                     <th class="col-sm-2">Requested</th>
@@ -34,7 +34,7 @@
             <tbody>
                 {% for request in requests %}
                     <tr>
-                        {% if current_user.my_role(members) in ("manager", "owner") %}
+                        {% if current_user.my_role(members) in ("manager", "owner", "np-owner") %}
                             <td>
                                 <a href="/groups/{{group.groupname}}/requests/{{request.id}}"
                                    class="btn btn-default btn-xs">
@@ -51,7 +51,7 @@
                         <td>{{ request.expiration|print_date }}</td>
                     </tr>
                     <tr>
-                        {% if current_user.my_role(members) in ("manager", "owner") %}
+                        {% if current_user.my_role(members) in ("manager", "owner", "np-owner") %}
                             <td>&nbsp;</td>
                         {% endif %}
                         <td colspan="5">

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -11,7 +11,8 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {% if current_user.my_role(members) == "owner" %}
+    <!-- Enable/Disable button. -->
+    {% if current_user.my_role(members) in ("owner", "np-owner") %}
         {% if group.enabled %}
             <button class="btn btn-danger" data-toggle="modal" data-target="#disableModal">
                 <i class="fa fa-minus"></i> Disable
@@ -23,10 +24,11 @@
         {% endif %}
     {% endif %}
 
+    <!-- Approve members. -->
     <div class="btn-group">
         <a href="/groups/{{group.name}}/requests"
            class="btn btn-default"><i class="fa fa-list"></i> Requests</a>
-        {% if current_user.my_role(members) in ("manager", "owner") and num_pending %}
+        {% if current_user.my_role(members) in ("manager", "owner", "np-owner") and num_pending %}
             <a href="/groups/{{group.name}}/requests?status=pending"
                title="Pending Requests"
                class="btn btn-default btn-pending">{{ num_pending }}</a>
@@ -36,13 +38,15 @@
     <a href="/groups/{{group.name}}/join"
        class="btn btn-success"><i class="fa fa-user"></i> Join</a>
 
-    {% if current_user.my_role(members) in ("manager", "owner") %}
+    <!-- Add member or edit group -->
+    {% if current_user.my_role(members) in ("manager", "owner", "np-owner") %}
         <a href="/groups/{{group.name}}/add"
            class="btn btn-success"><i class="fa fa-plus-circle"></i> Add Member</a>
         <a href="/groups/{{group.name}}/edit"
            class="btn btn-primary"><i class="fa fa-edit"></i> Edit</a>
     {% endif %}
 
+    <!-- Owners can't leave a group. -->
     {% if current_user.my_role(members) in ("member", "manager") %}
         <a href="/groups/{{group.name}}/leave"
            class="btn btn-danger"><i class="fa fa-sign-out"></i> Leave</a>

--- a/grouper/fe/templates/help.html
+++ b/grouper/fe/templates/help.html
@@ -24,12 +24,12 @@ of C.) That's all there is to it.  Technically speaking, the users and groups co
 the nodes of a <a href="http://en.wikipedia.org/wiki/Directed_acyclic_graph">directed
 acyclic graph</a> and a user or group is a member of any of its ancestors.</p>
 
-<h3>What's the difference between the member, manager, and owner roles?</h3>
-<p>These are the three types of group membership for users: a member just inherits the
-group's permissions, a manager is allowed to process requests to join a group, and an
-owner has full control over the group (including the ability to change the membership type
-of other users or add/remove the group's permissions.)  Technically, groups are members of
-other groups.</p>
+<h3>What's the difference between the member, manager, owner, and np-owner roles?</h3>
+<p>These are the types of group membership for users: a member just inherits the group's
+permissions, a manager is allowed to process requests to join a group, and an owner has
+full control over the group (including the ability to change the membership type of other
+users or add/remove the group's permissions.)  An np-owner is like an owner but does not
+inherit permissions from the group. Technically, groups are members of other groups.</p>
 
 <h3>What's the deal with permissions?</h3>
 <p>Grouper <a href="/permissions">permissions</a> are just enumerated strings. First,
@@ -61,8 +61,8 @@ grant the permission to grant ({{grant_perm.name}}, prefix.*).</p>
 <h3>How does auditing work?</h3>
 <p>Certain grouper permissions are designated as audited permissions. Groups with at least
 one audited permission become audited groups.  Users with the {{permission(audit_perm)}}
-permission (any argument) are considered auditors.  Only auditors can be the manager or
-owner of an audited group.</p>
+permission (any argument) are considered auditors.  Only auditors can be the manager,
+owner, or np-owner of an audited group.</p>
 
 <!-- TODO: change once auditing tooling is ready! -->
 <p>We're working on tooling to facilitate regular monitoring of both members of audited

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -79,6 +79,7 @@ A 'role' describes someone's ability to control the group. There are three types
 <ul><li><strong>member</strong> has no special power</li>
 <li><strong>manager</strong> is allowed to process requests to join the group</li>
 <li><strong>owner</strong> has full control of the group</li></ul>
+<li><strong>np-owner</strong> has full control of the group but doesn't receive the group's permissions</li></ul>
 {% elif subj == "audited_group" %}
 One or more of the permissions that apply to this group have auditing
 enabled. Membership in this group is regularly reviewed.
@@ -152,7 +153,7 @@ enabled. Membership in this group is regularly reviewed.
     <tr>
         <td>
             {% if member.name != current_user.name and
-                (current_user.my_role(members) == "owner" or
+                (current_user.my_role(members) in ("owner", "np-owner") or
                  (current_user.my_role(members) == "manager" and
                   ROLES[member.role] == "member"))
             %}

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -43,9 +43,10 @@ REQUEST_STATUS_CHOICES = {
     "cancelled": set([]),
 }
 GROUP_EDGE_ROLES = (
-    "member",   # Belongs to the group. Nothing more.
-    "manager",  # Make changes to the group / Approve requests.
-    "owner",    # Same as manager plus enable/disable group and make Users owner.
+    "member",    # Belongs to the group. Nothing more.
+    "manager",   # Make changes to the group / Approve requests.
+    "owner",     # Same as manager plus enable/disable group and make Users owner.
+    "np-owner",  # Same as owner but don't inherit permissions.
 )
 
 MappedPermission = namedtuple('MappedPermission',
@@ -261,7 +262,7 @@ class User(Model):
     def can_manage(self, group):
         """Determine if this user can manage the given group
 
-        This returns true if this user object is a manager or owner of the given group.
+        This returns true if this user object is a manager, owner, or np-owner of the given group.
 
         Args:
             group (Group): Group to check permissions against.
@@ -272,7 +273,7 @@ class User(Model):
         if not group:
             return False
         members = group.my_members()
-        if self.my_role(members) in ("owner", "manager"):
+        if self.my_role(members) in ("owner", "np-owner", "manager"):
             return True
         return False
 
@@ -681,7 +682,7 @@ class Group(Model):
                 status: pending/actioned, whether the request needs approval
                         or should be immediate
                 expiration: datetime object when membership should expire.
-                role: member/manager/owner of the Group.
+                role: member/manager/owner/np-owner of the Group.
         """
         now = datetime.utcnow()
         member_type = user_or_group.member_type

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -22,9 +22,11 @@ def standard_graph(session, graph, users, groups, permissions):
 
     add_member(groups["tech-ops"], users["zay"], role="owner")
     add_member(groups["tech-ops"], users["gary"])
+    add_member(groups["tech-ops"], users["figurehead"], role="np-owner")
     grant_permission(groups["tech-ops"], permissions["ssh"], argument="shell")
 
     add_member(groups["security-team"], users["oliver"], role="owner")
+    add_member(groups["security-team"], users["figurehead"], role="member")
 
     add_member(groups["sad-team"], users["zorkian"], role="owner")
     add_member(groups["sad-team"], users["oliver"])
@@ -78,7 +80,7 @@ def graph(session):
 def users(session):
     users = {
         username: User.get_or_create(session, username=username)[0]
-        for username in ("gary", "zay", "zorkian", "oliver", "testuser")
+        for username in ("gary", "zay", "zorkian", "oliver", "testuser", "figurehead")
     }
     session.commit()
     return users

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -31,6 +31,8 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
     assert sorted(get_user_permissions(graph, "zorkian")) == [
         "audited:", PERMISSION_AUDITOR + ":", "ssh:*", "sudo:shell"]
     assert sorted(get_user_permissions(graph, "testuser")) == []
+    assert sorted(get_user_permissions(graph, "figurehead")) == [
+        "sudo:shell"]
 
 
 class PermissionTests(unittest.TestCase):


### PR DESCRIPTION
Create new role "No-Permissions Owner" (a.k.a. "np-owner") that has full group ownership but does not provide permission inheritance via the group.  A user serving as np-owner in a group can still obtain permissions if they have membership in other groups.

Bugfixes: allow managers to remove other managers, don't allow managers to add owners.