### PR TITLE
Add group creator role choice; refresh before redirecting

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -66,8 +66,21 @@ class PermissionCreateForm(Form):
     ])
     description = TextAreaField("Description")
 
+class GroupCreateForm(Form):
+    creatorrole = SelectField("Creator role", choices=[
+        ("owner", "Owner"), ("np-owner", "No-Permissions Owner"),
+    ], default="owner")
+    groupname = TextField("Name", [
+        validators.Length(min=3, max=32),
+        validators.Required(),
+        ValidateRegex(constants.NAME_VALIDATION),
+    ])
+    description = TextAreaField("Description")
+    canjoin = SelectField("Who Can Join?", choices=[
+        ("canjoin", "Anyone"), ("canask", "Must Ask"),
+    ], default="canask")
 
-class GroupForm(Form):
+class GroupEditForm(Form):
     groupname = TextField("Name", [
         validators.Length(min=3, max=32),
         validators.Required(),

--- a/grouper/fe/templates/forms/group.html
+++ b/grouper/fe/templates/forms/group.html
@@ -11,6 +11,9 @@
 {%- endmacro %}
 
 
+{% if form.creatorrole %}
+    {{ form_field(form.creatorrole, 3, 6, class_="form-control") }}
+{% endif %}
 {{ form_field(form.groupname, 3, 8, class_="form-control") }}
 {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
 {{ form_field(form.canjoin, 3, 4, class_="form-control") }}

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -110,6 +110,10 @@ class GrouperHandler(tornado.web.RequestHandler):
         })
         return namespace
 
+    def redirect(self, route):
+        self.graph.update_from_db(self.session)
+        tornado.web.RequestHandler.redirect(self, route)
+
     def render_template(self, template_name, **kwargs):
         template = self.application.my_settings["template_env"].get_template(template_name)
         content = template.render(kwargs)


### PR DESCRIPTION
Allow group creators to choose either regular Owner or No-Permissions Owner for their role in the new group.  Refresh the graph just before redirects so the results of POSTs are immediately visible.