### PR TITLE
Populate the graph with both enabled and disabled groups and users.

### DIFF
--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -248,13 +248,9 @@ class GroupGraph(object):
         return session.query(
             label("type", literal("User")),
             label("name", User.username)
-        ).filter(
-            User.enabled == True
         ).union(session.query(
             label("type", literal("Group")),
             label("name", Group.groupname))
-        ).filter(
-            Group.enabled == True
         ).all()
 
     @staticmethod


### PR DESCRIPTION
Include disabled users and groups in the graph.  Disabled groups have no members and don't belong to other groups, but still display their description and direct permissions; -disable/+enable are inverses for groups.  In this implementation, re-enabled users start with no group memberships, so -disable/+enable are not inverses for users.