### PR TITLE
Keep disabled users and groups out of the in-memory graph.

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -32,6 +32,7 @@ RESERVED_NAMES = [
     r"^admin",
     r"^test",
     r"^[^.]*$",
+    r"^[0-9]+$", # Reserved in order to select user or group by id.
 ]
 
 # Maximum length a name can be. This applies to user names and permission arguments.

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -20,6 +20,7 @@ from .forms import (
     GroupRequestModifyForm, PublicKeyForm, PermissionCreateForm,
     PermissionGrantForm, GroupEditMemberForm,
 )
+from ..graph import NoSuchUser, NoSuchGroup
 from ..models import (
     User, Group, Request, PublicKey, Permission, PermissionMap, AuditLog, GroupEdge, Counter,
     GROUP_JOIN_CHOICES, REQUEST_STATUS_CHOICES, GROUP_EDGE_ROLES, OBJ_TYPES,
@@ -96,8 +97,9 @@ class UserView(GrouperHandler):
 
         try:
             user_md = self.graph.get_user_details(user.name)
-        except KeyError:
-            # User is probably very new, so they have no metadata yet.
+        except NoSuchUser:
+            # Either user is probably very new, so they have no metadata yet, or
+            # they're disabled, so we've excluded them from the in-memory graph.
             user_md = {}
 
         groups = user.my_groups()
@@ -471,8 +473,9 @@ class GroupView(GrouperHandler):
 
         try:
             group_md = self.graph.get_group_details(group.name)
-        except KeyError:
-            # New group, no metadata yet.
+        except NoSuchGroup:
+            # Very new group with no metadata yet, or it has been disabled and
+            # excluded from in-memory cache.
             group_md = {}
 
         members = group.my_members()


### PR DESCRIPTION
This is a safer solution to the 500s we were seeing in the UserView handler.  It's preferable to keep disabled users and groups out of the in-memory graph in order to simplify UX, correctness of clients, etc.