### PR TITLE
Increase the rows returned by frontend.  Raise the hard limit.

### DIFF
--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -1,5 +1,3 @@
-# TODO(mildorf): we should refresh the graph after every write operation so that
-# redirects at the end of posts will include their effects.
 from datetime import datetime
 import operator
 
@@ -42,9 +40,9 @@ class Search(GrouperHandler):
     def get(self):
         query = self.get_argument("query", "")
         offset = int(self.get_argument("offset", 0))
-        limit = int(self.get_argument("limit", 10))
-        if limit > 50:
-            limit = 50
+        limit = int(self.get_argument("limit", 100))
+        if limit > 9000:
+            limit = 9000
 
         groups = self.session.query(
             label("type", literal("Group")),
@@ -365,9 +363,9 @@ class PermissionsView(GrouperHandler):
     '''
     def get(self,audited_only=False):
         offset = int(self.get_argument("offset", 0))
-        limit = int(self.get_argument("limit", 10))
-        if limit > 50:
-            limit = 50
+        limit = int(self.get_argument("limit", 100))
+        if limit > 9000:
+            limit = 9000
 
         permissions = self.graph.get_permissions(audited=audited_only)
         total = len(permissions)
@@ -409,9 +407,9 @@ class PermissionView(GrouperHandler):
 class UsersView(GrouperHandler):
     def get(self):
         offset = int(self.get_argument("offset", 0))
-        limit = int(self.get_argument("limit", 10))
-        if limit > 50:
-            limit = 50
+        limit = int(self.get_argument("limit", 100))
+        if limit > 9000:
+            limit = 9000
 
         users = (
             self.session.query(User)
@@ -715,9 +713,9 @@ class GroupRequests(GrouperHandler):
 
         status = self.get_argument("status", None)
         offset = int(self.get_argument("offset", 0))
-        limit = int(self.get_argument("limit", 10))
-        if limit > 50:
-            limit = 50
+        limit = int(self.get_argument("limit", 100))
+        if limit > 9000:
+            limit = 9000
 
         requests = group.my_requests(status).order_by(
             Request.requested_at.desc()
@@ -737,9 +735,9 @@ class GroupRequests(GrouperHandler):
 class GroupsView(GrouperHandler):
     def get(self, audited_only=False):
         offset = int(self.get_argument("offset", 0))
-        limit = int(self.get_argument("limit", 10))
-        if limit > 50:
-            limit = 50
+        limit = int(self.get_argument("limit", 100))
+        if limit > 9000:
+            limit = 9000
 
         if audited_only:
             groups = self.graph.get_groups(audited=True, directly_audited=False)

--- a/grouper/fe/templates/group-requests.html
+++ b/grouper/fe/templates/group-requests.html
@@ -11,7 +11,7 @@
 
 {% block headingbuttons %}
     {{ dropdown("status", status, statuses, True) }}
-    {{ dropdown("limit", limit, [10, 25, 50]) }}
+    {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
 {% endblock %}
 

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {{ dropdown("limit", limit, [10, 25, 50]) }}
+    {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
     <button class="btn btn-success" data-toggle="modal" data-target="#createModal">
         <i class="fa fa-plus"></i> Create

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {{ dropdown("limit", limit, [10, 25, 50]) }}
+    {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
     {% if can_create %}
     <a class="btn btn-success" href="/permissions/create">

--- a/grouper/fe/templates/search.html
+++ b/grouper/fe/templates/search.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {{ dropdown("limit", limit, [10, 25, 50]) }}
+    {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
 {% endblock %}
 

--- a/grouper/fe/templates/users.html
+++ b/grouper/fe/templates/users.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {{ dropdown("limit", limit, [10, 25, 50]) }}
+    {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
 {% endblock %}
 


### PR DESCRIPTION
Return 10x as many results from the frontend.  Allow users to enter much large values manually.