### PR TITLE
Expose disabled groups/users view; route cleanup.

### DIFF
--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -3,11 +3,9 @@ from ..constants import NAME_VALIDATION, NAME2_VALIDATION, PERMISSION_VALIDATION
 
 HANDLERS = [
     (r"/", handlers.Index),
-    (r"/audited-groups", handlers.AuditedGroupsView),
     (r"/groups", handlers.GroupsView),
     (r"/permissions/create", handlers.PermissionsCreate),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), handlers.PermissionView),
-    (r"/audited-permissions", handlers.AuditedPermissionsView),
     (r"/permissions", handlers.PermissionsView),
     (
         r"/permissions/{}/enable-auditing".format(PERMISSION_VALIDATION),

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -5,34 +5,42 @@
     {% if audited_groups %}
       Audited
     {% endif %}
+    {% if not enabled %}
+      Disabled
+    {% endif %}
     Groups
 {% endblock %}
 
 {% block subheading %}
-    {{total}}
-    {% if audited_groups %}
-      audited
-    {% endif %}
-    group(s)
+    {{total}} group(s)
 {% endblock %}
 
 {% block headingbuttons %}
     {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
-    <button class="btn btn-success" data-toggle="modal" data-target="#createModal">
-        <i class="fa fa-plus"></i> Create
-    </button>
-    {% if audited_groups %}
-    <a class="btn btn-warning" href="/groups?limit={{limit}}">
-        <i class="fa"></i> Show all groups
-    </a>
+    {% if enabled %}
+      {% if audited_groups %}
+      <a class="btn btn-warning" href="/groups?limit={{limit}}">
+          <i class="fa"></i> Show all groups
+      </a>
+      {% else %}
+      <button class="btn btn-success" data-toggle="modal" data-target="#createModal">
+          <i class="fa fa-plus"></i> Create
+      </button>
+      <a class="btn btn-warning" href="/groups?limit={{limit}}&audited=1">
+          <i class="fa"></i> Show audited groups
+      </a>
+      {% endif %}
+      <a class="btn btn-default" href="/groups?limit={{limit}}&enabled=0">
+          <i class="fa"></i> Show disabled groups
+      </a>
     {% else %}
-    <a class="btn btn-warning" href="/audited-groups?limit={{limit}}">
-        <i class="fa"></i> Show audited groups only
-    </a>
+      <a class="btn btn-default" href="/groups?limit={{limit}}&enabled=1">
+          <i class="fa"></i> Show enabled groups
+      </a>
     {% endif %}
 {% endblock %}
-
+    
 {% block content %}
     <div class="col-md-10 col-md-offset-1">
         <table class="table table-elist">
@@ -73,6 +81,7 @@
         </table>
     </div>
 
+{% if forms %}
 <div class="modal fade" id="createModal" tabindex="-1" role="dialog"
       aria-labelledby="createModal" aria-hidden="true">
     <div class="modal-dialog">
@@ -98,7 +107,7 @@
         </div>
     </div>
 </div>
-
+{% endif %}
 
 {% endblock %}
 

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -15,17 +15,17 @@
 {% block headingbuttons %}
     {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
+    {% if audited_permissions %}
+    <a class="btn btn-warning" href="/permissions?limit={{limit}}&audited=0">
+        <i class="fa"></i> Show all permissions
+    </a>
+    {% else %}
     {% if can_create %}
     <a class="btn btn-success" href="/permissions/create">
         <i class="fa fa-plus"></i> Create
     </a>
     {% endif %}
-    {% if audited_permissions %}
-    <a class="btn btn-warning" href="/permissions?limit={{limit}}">
-        <i class="fa"></i> Show all permissions
-    </a>
-    {% else %}
-    <a class="btn btn-warning" href="/audited-permissions?limit={{limit}}">
+    <a class="btn btn-warning" href="/permissions?limit={{limit}}&audited=1">
         <i class="fa"></i> Show audited permissions only
     </a>
     {% endif %}

--- a/grouper/fe/templates/users.html
+++ b/grouper/fe/templates/users.html
@@ -2,6 +2,9 @@
 {% from 'macros/ui.html' import account, paginator, dropdown with context %}
 
 {% block heading %}
+    {% if not enabled %}
+      Disabled
+    {% endif %}
     Users
 {% endblock %}
 
@@ -12,6 +15,16 @@
 {% block headingbuttons %}
     {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
+    {% if enabled %}
+      <a class="btn btn-default" href="/users?limit={{limit}}&enabled=0">
+          <i class="fa"></i> Show disabled users
+      </a>
+    {% else %}
+      <a class="btn btn-default" href="/users?limit={{limit}}&enabled=1">
+          <i class="fa"></i> Show enabled users
+      </a>
+    {% endif %}
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Make disabled users and groups discoverable on the frontend.  Serve the variously-filtered groups, users, and permissions views from /groups, /users, and /permissions using arguments instead of different routes.  Fixes to the buttons that are shown on different views (e.g. we can't directly create an audited group.)