### PR TITLE
Fix group creation: errant if statement.

### DIFF
--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -40,7 +40,7 @@
       </a>
     {% endif %}
 {% endblock %}
-    
+
 {% block content %}
     <div class="col-md-10 col-md-offset-1">
         <table class="table table-elist">
@@ -81,7 +81,6 @@
         </table>
     </div>
 
-{% if forms %}
 <div class="modal fade" id="createModal" tabindex="-1" role="dialog"
       aria-labelledby="createModal" aria-hidden="true">
     <div class="modal-dialog">
@@ -107,7 +106,6 @@
         </div>
     </div>
 </div>
-{% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
I inadvertently inserted a pointless if statement around the groups createModal during route cleanup.  Removing it restores the ability to create groups.