### PR TITLE
Send emails when SSH keys have been changed.

### DIFF
--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -1229,6 +1229,12 @@ class PublicKeyAdd(GrouperHandler):
                      'Added public key: {}'.format(pubkey.fingerprint),
                      on_user_id=user.id)
 
+        self.send_email([user.name], 'Public SSH key added', 'ssh_keys_changed', {
+            "actioner": self.current_user.name,
+            "changed_user": user.name,
+            "action": "added",
+        })
+
         return self.redirect("/users/{}".format(user.name))
 
 
@@ -1265,6 +1271,13 @@ class PublicKeyDelete(GrouperHandler):
         AuditLog.log(self.session, self.current_user.id, 'delete_public_key',
                      'Deleted public key: {}'.format(key.fingerprint),
                      on_user_id=user.id)
+
+        self.send_email([user.name], 'Public SSH key removed', 'ssh_keys_changed', {
+            "actioner": self.current_user.name,
+            "changed_user": user.name,
+            "action": "removed",
+        })
+
 
         return self.redirect("/users/{}".format(user.name))
 

--- a/grouper/fe/templates/email/ssh_keys_changed_html.tmpl
+++ b/grouper/fe/templates/email/ssh_keys_changed_html.tmpl
@@ -1,0 +1,14 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}SSH Keys Changed{% endblock %}
+
+{% block content %}
+
+<p>Public SSH key {{ action }} for <strong><a href="{{url}}/users/{{changed_user}}">{{ changed_user }}</a></strong>.</p>
+
+{% if changed_user != actioner %}
+    <p>This edit was made by
+    <a href="{{url}}/users/{{actioner}}">{{ actioner }}</a>.</p>
+{% endif %}
+
+{% endblock %}

--- a/grouper/fe/templates/email/ssh_keys_changed_text.tmpl
+++ b/grouper/fe/templates/email/ssh_keys_changed_text.tmpl
@@ -1,0 +1,14 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}SSH Keys Changed{% endblock %}
+
+{% block content %}
+
+Public SSH key {{ action }} for {{ changed_user }}.
+
+{% if changed_user != actioner %}
+    This edit was made by
+    {{ actioner }}.
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Email a user when their public SSH keys are edited.  If edited by someone else, include the actioner in the email.