### PR TITLE
Fix DB url caching, race condtion, add retries.

### DIFF
--- a/grouper/util.py
+++ b/grouper/util.py
@@ -14,6 +14,7 @@ _TRUTHY = set([
 _DB_URL_REFRESH_TIME = 0
 _DB_URL_REFRESH_JITTER = 30
 _DB_URL_CACHED = None
+_DB_URL_LOCK = threading.Lock()
 
 
 def qp_to_bool(arg):
@@ -32,21 +33,31 @@ def try_update(dct, update):
     dct.update(update)
 
 
-def get_database_url(settings):
+def get_database_url(settings, retries=3, retry_wait_seconds=1):
     """Given settings, load a database URL either from our executable source or the bare string."""
     if not settings.database_source:
+        assert settings.database is not None
         return settings.database
 
     # Use a cached/jitter so we don't hit the script for every request.
-    global _DB_URL_CACHED, _DB_URL_REFRESH_TIME, _DB_URL_REFRESH_JITTER
-    if _DB_URL_REFRESH_TIME > time.time():
-        return _DB_URL_CACHED
-    _DB_URL_REFRESH_TIME = time.time() + (insecure_random.random() * _DB_URL_REFRESH_JITTER)
-    try:
-        url = subprocess.check_output([settings.database_source])
-    except subprocess.CalledProcessError:
-        return None
-    return url.strip()
+    global _DB_URL_CACHED, _DB_URL_REFRESH_TIME, _DB_URL_REFRESH_JITTER, _DB_URL_LOCK
+    with _DB_URL_LOCK:
+        if _DB_URL_REFRESH_TIME > time.time() and _DB_URL_CACHED is not None:
+            return _DB_URL_CACHED
+        _DB_URL_REFRESH_TIME = time.time() + (insecure_random.random() * _DB_URL_REFRESH_JITTER)
+        retry = 0
+        while True:
+            try:
+                url = subprocess.check_output([settings.database_source])
+                _DB_URL_CACHED = url.strip()
+                return _DB_URL_CACHED
+            except subprocess.CalledProcessError as e:
+                logging.info("database_source: " + str(settings.database_source))
+                logging.error(e)
+                retry += 1
+                if retry > retries:
+                    raise
+                time.sleep(retry_wait_seconds)
 
 
 def send_email_raw(settings, recipient_list, msg_raw):


### PR DESCRIPTION
OperationalErrors already trigger Session.configure(bind=get_db_engine(get_database_url(settings))) in several places including the asynchronous threads, which enables database failover.  This fixes a couple issues in the way get_database_url behaves under those conditions and exposes failure modes as exceptions rather than failing quietly.