### PR TITLE
Add asynchronous config-refreshing.

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -67,7 +67,7 @@ def main(argv):
                         help="Display version information.")
     parser.add_argument("-p", "--port", type=int, default=None, help="Override port in config.")
     args = parser.parse_args()
-    settings.update_from_config(args.config, "api")
+    settings.start_config_thread(args.config, "api")
 
     log_level = get_loglevel(args)
     logging.basicConfig(

--- a/bin/grouper-ctl
+++ b/bin/grouper-ctl
@@ -278,7 +278,7 @@ def main():
     capabilities_rm_parser.add_argument("capability", choices=Capabilities.words.keys())
 
     args = parser.parse_args()
-    settings.update_from_config(args.config)
+    settings.start_config_thread(args.config)
 
     log_level = get_loglevel(args)
     logging.basicConfig(

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -72,7 +72,7 @@ def main(argv):
                         help="Name of the deployment.")
 
     args = parser.parse_args()
-    settings.update_from_config(args.config, "fe")
+    settings.start_config_thread(args.config, "fe")
 
     if settings.debug and settings.num_processes > 1:
         logging.fatal("Debug mode does not support multiple processes.")

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -1,9 +1,16 @@
+import logging
+import threading
+import time
 import yaml
 
+from expvar.stats import stats
 
 class Settings(object):
     def __init__(self, initial_settings):
         self.settings = initial_settings
+        self.lock = threading.Lock()
+        self.logger = logging.getLogger(__name__)
+        self._loading_thread_started = False
 
     @classmethod
     def from_settings(cls, settings, initial_settings=None):
@@ -13,7 +20,8 @@ class Settings(object):
             _settings.update(initial_settings)
         return cls(_settings)
 
-    def update_from_config(self, filename, section=None):
+    def _update_from_config(self, filename, section=None):
+        self.logger.info("Loading " + filename)
         with open(filename) as config:
             data = yaml.safe_load(config.read())
 
@@ -25,6 +33,7 @@ class Settings(object):
         for key, value in settings.iteritems():
             key = key.lower()
 
+            # Limit the parts of the config file that can have an effect.
             if key not in self.settings:
                 continue
 
@@ -32,16 +41,42 @@ class Settings(object):
             if override is not None and callable(override):
                 value = override(value)
 
+            self[key] = value
+
+
+    def start_config_thread(self, filename, section=None, refresh_config_seconds=10):
+        """
+        Start a thread to reload the given config file and section periodically.
+        Load the config once before returning.  This function must be called at
+        most once.
+        """
+        assert not self._loading_thread_started, "start_config_thread called twice!"
+        self._update_from_config(filename, section=section)
+        def refresh_config_loop():
+            while True:
+                time.sleep(refresh_config_seconds)
+                try:
+                    self._update_from_config(filename, section=section)
+                    stats.set_gauge("successful-config-update", 1)
+                except (IOError, yaml.parser.ParserError):
+                    stats.set_gauge("successful-config-update", 0)
+        threading.Thread(target=refresh_config_loop).start()
+        self._loading_thread_started = True
+
+    def __setitem__(self, key, value):
+        with self.lock:
             self.settings[key] = value
 
     def __getitem__(self, key):
-        return self.settings[key]
+        with self.lock:
+            return self.settings[key]
 
     def __getattr__(self, name):
-        try:
-            return self.settings[name]
-        except KeyError as err:
-            raise AttributeError(err)
+        with self.lock:
+            try:
+                return self.settings[name]
+            except KeyError as err:
+                raise AttributeError(err)
 
 
 settings = Settings({


### PR DESCRIPTION
Keep Grouper configuration fresh by reloading the config file every few seconds.