### PR TITLE
Adding 'nobody' as who-can-join group option.

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -78,6 +78,7 @@ class GroupCreateForm(Form):
     description = TextAreaField("Description")
     canjoin = SelectField("Who Can Join?", choices=[
         ("canjoin", "Anyone"), ("canask", "Must Ask"),
+        ("nobody", "Nobody"),
     ], default="canask")
 
 class GroupEditForm(Form):
@@ -89,6 +90,7 @@ class GroupEditForm(Form):
     description = TextAreaField("Description")
     canjoin = SelectField("Who Can Join?", choices=[
         ("canjoin", "Anyone"), ("canask", "Must Ask"),
+        ("nobody", "Nobody"),
     ], default="canask")
 
 

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -971,6 +971,15 @@ class GroupJoin(GrouperHandler):
                 ]
             )
 
+        if group.canjoin == "nobody":
+            fail_message = 'This group cannot be joined at this time.'
+            return self.render(
+                "group-join.html", form=form, group=group,
+                alerts=[
+                    Alert('danger', fail_message)
+                ]
+            )
+
         expiration = None
         if form.data["expiration"]:
             expiration = datetime.strptime(form.data["expiration"], "%m/%d/%Y")

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -35,8 +35,12 @@
         {% endif %}
     </div>
 
+    <!-- Show the join button if the user isn't already a member and the group
+         isn't invite-only. -->
+    {% if not current_user.my_role(members) and group.canjoin != "nobody" %}
     <a href="/groups/{{group.name}}/join"
        class="btn btn-success"><i class="fa fa-user"></i> Join</a>
+    {% endif %}
 
     <!-- Add member or edit group -->
     {% if current_user.my_role(members) in ("manager", "owner", "np-owner") %}

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -62,8 +62,10 @@
                     <td>
                         {% if group.canjoin == "canjoin" %}
                             Anyone
-                        {% else %}
+                        {% elif group.canjoin == "canask" %}
                             Must Ask
+                        {% else %}
+                            Nobody
                         {% endif %}
                     </td>
 		    {% if audited_groups %}

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -32,8 +32,13 @@ OBJ_TYPES_IDX = ("User", "Group", "Request", "RequestStatusChange")
 OBJ_TYPES = {obj_type: idx for idx, obj_type in enumerate(OBJ_TYPES_IDX)}
 
 GROUP_JOIN_CHOICES = {
-    "canjoin": "actioned",  # Anyone can join with automatic approval
-    "canask": "pending",   # Anyone can ask to join this group
+    # Anyone can join with automatic approval
+    "canjoin": "actioned",
+    # Anyone can ask to join this group
+    "canask": "pending",
+    # Only those invited may join (should never be a valid status because no
+    # join request should be generated for such groups!)
+    "nobody": "<integrityerror>",
 }
 
 REQUEST_STATUS_CHOICES = {


### PR DESCRIPTION
Users won't be able to join groups that are invite-only. Show this on
the groups page and hide the join button on the individual group page.

While I'm at it, don't show the Join button if someone is already in a group.