### PR TITLE
Identify role users; API servers only serve them if asked

### DIFF
--- a/bin/grouper-ctl
+++ b/bin/grouper-ctl
@@ -116,7 +116,7 @@ def user_command(args):
     if not user:
         if args.subcommand == "create":
             print "No such user %s, creating..." % args.username
-            user = models.User(username=args.username).add(session)
+            user = models.User(username=args.username, role_user=args.role_user).add(session)
             session.commit()
         else:
             print "No such user %s" % args.username
@@ -231,6 +231,8 @@ def main():
     user_create_parser = user_subparser.add_parser(
         "create", help="Create a new user account")
     user_create_parser.add_argument("username")
+    user_create_parser.add_argument("--role-user", default=False, action="store_true",
+                                    help="If given, identifies user as a role user.")
 
     user_key_parser = user_subparser.add_parser(
         "add_public_key", help="Add public key to user")

--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -42,11 +42,14 @@ class GraphHandler(RequestHandler):
 class Users(GraphHandler):
     def get(self, name=None):
         cutoff = int(self.get_argument("cutoff", 100))
+        include_role_users = self.get_argument("include_role_users", "no") == "yes"
 
         with self.graph.lock:
             if not name:
                 return self.success({
-                    "users": sorted(self.graph.user_metadata.keys()),
+                    "users": sorted([k
+                                     for k,v in self.graph.user_metadata.iteritems()
+                                     if include_role_users or (not v["role_user"])]),
                 })
 
             if name in self.graph.user_metadata:

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -132,7 +132,13 @@ enabled. Membership in this group is regularly reviewed.
 {% if type == None %}
 <a class="account-link" href="/{{ user.type | lower }}s/{{ user.name }}">
     <i class="fa fa-user{% if user.type.lower() == 'group' %}s{% endif %}"></i> 
+    {% if user.role_user %}
+    <i>
+    {% endif %}
     {{ user.name }}
+    {% if user.role_user %}
+    (role)</i>
+    {% endif %}
 </a>
 {% else %}
 <a class="account-link" href="/{{ type | lower }}s/{{ user }}">

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -6,7 +6,9 @@
 {% endblock %}
 
 {% block subheading %}
-    {{user.username}} {% if not user.enabled %}<small>(disabled)</small>{% endif %}
+    {{user.username}}
+    {% if user.role_user %}<small>(role)</small>{% endif %}
+    {% if not user.enabled %}<small>(disabled)</small>{% endif %}
 {% endblock %}
 
 {% block headingbuttons %}

--- a/grouper/fe/templates/users.html
+++ b/grouper/fe/templates/users.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {{ dropdown("limit", limit, [100, 250, 500]) }}
+    {{ dropdown("limit", limit, [100, 250, 500, 1000]) }}
     {{ paginator(offset, limit, total) }}
     {% if enabled %}
       <a class="btn btn-default" href="/users?limit={{limit}}&enabled=0">

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -151,6 +151,7 @@ class GroupGraph(object):
         for user in users:
             out[user.username] = {
                 "enabled": user.enabled,
+                "role_user": user.role_user,
                 "public_keys": [
                     {
                         "public_key": key.public_key,

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -238,6 +238,7 @@ class User(Model):
     username = Column(String(length=MAX_NAME_LENGTH), unique=True, nullable=False)
     capabilities = Column(Integer, default=0, nullable=False)
     enabled = Column(Boolean, default=True, nullable=False)
+    role_user = Column(Boolean, default=False, nullable=False)
 
     @hybrid_property
     def name(self):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -82,6 +82,7 @@ def users(session):
         username: User.get_or_create(session, username=username)[0]
         for username in ("gary", "zay", "zorkian", "oliver", "testuser", "figurehead")
     }
+    users["role"] = User.get_or_create(session, username="role", role_user=True)
     session.commit()
     return users
 


### PR DESCRIPTION
Role users can be pretty confusing in certain contexts. Make them opt-in for API server clients, via GET argument include_role_users=yes, and identify them on the front end.