### PR TITLE
Add a plugin method for site-specific error handling

### DIFF
--- a/grouper/models.py
+++ b/grouper/models.py
@@ -153,6 +153,10 @@ def load_plugins(plugin_dir, service_name):
     for plugin in Plugins:
         plugin.configure(service_name)
 
+def get_plugins():
+    """Get a list of loaded plugins."""
+    global Plugins
+    return list(Plugins)
 
 def flush_transaction(method):
     @functools.wraps(method)

--- a/grouper/plugin.py
+++ b/grouper/plugin.py
@@ -27,3 +27,18 @@ class BasePlugin(object):
         (grouper-api or grouper-fe).
         """
         pass
+
+    def log_exception(self, request, status, exception, stack):
+        """
+        Called when responding with statuses 400, 403, 404, and 500.
+
+        Args:
+            request (tornado.httputil.HTTPServerRequest): the request being handled.
+            status (int): the response status.
+            exception (Exception): either a tornado.web.HTTPError or an unexpected exception.
+            stack (list): "pre-processed" stack trace entries for traceback.format_list.
+
+        Returns:
+            The return code of this method is ignored.
+        """
+        pass


### PR DESCRIPTION
Add an exception handler to the base plugin.  Make the API servers return code 500 rather than no response when an internal error comes up in a handler.