### PR TITLE
do not strip name input prior to validation. this ensures leading/tra…

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -17,7 +17,7 @@ class ValidateRegex(object):
         self._re = re.compile(self.regex)
 
     def __call__(self, form, field):
-        if not self._re.match(field.data.strip()):
+        if not self._re.match(field.data):
             raise ValidationError("Field must match '{}'".format(self.regex))
 
 


### PR DESCRIPTION
…iling whitespace does not make it into name values. this extra whitespace gets escaped in subsequent links which routes doesn't know what to do with.