### PR TITLE
Development environment enhancements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,18 +41,20 @@ for running on development instances.
 Creating a development instance:
 
 .. code:: bash
+    export PYTHONPATH=$(pwd)
+    export GROUPER_SETTINGS=$(pwd)/config/dev.yaml
 
     # Setup the database.
-    PYTHONPATH=. bin/grouper-ctl -vvvc config/dev.yaml sync_db
+    bin/grouper-ctl sync_db
 
     # Run the development reverse proxy
-    PYTHONPATH=. bin/grouper-ctl -vvc config/dev.yaml user_proxy $USER@example.com
+    bin/grouper-ctl -vv user_proxy $USER@example.com
 
     # Run the frontend server
-    PYTHONPATH=. bin/grouper-fe --config=config/dev.yaml -vv
+    bin/grouper-fe -vv
 
     # Run the graph/api server
-    PYTHONPATH=. bin/grouper-api --config=config/dev.yaml  -vv
+    bin/grouper-api -vv
 
 
 Setting up the first groups and permissions
@@ -64,15 +66,17 @@ account and grant powers independent of the usual way and are given out manually
 via the following commands:
 
 .. code:: bash
+    export PYTHONPATH=$(pwd)
+    export GROUPER_SETTINGS=$(pwd)/config/dev.yaml
 
     # Allow user to set up groups and group-membership.
-    PYTHONPATH=. bin/grouper-ctl -c config/dev.yaml -vv \
+    bin/grouper-ctl -vv \
         capabilities add $USER@example.com group_admin
 
     # Allow someone to enable/disable user accounts.
-    PYTHONPATH=. bin/grouper-ctl -c config/dev.yaml -vv \
+    bin/grouper-ctl -vv \
         capabilities add $USER@example.com user_admin
 
     # Allow someone to create permissions.
-    PYTHONPATH=. bin/grouper-ctl -c config/dev.yaml -vv \
+    bin/grouper-ctl -vv \
         capabilities add $USER@example.com permission_admin

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,11 @@ Creating a development instance:
     # Setup the database.
     bin/grouper-ctl sync_db
 
+    ## You can either run all the various servers and the reverse-proxy
+    ## via a helper script:
+    tools/run-dev --user $USER@example.com
+
+    ## Or separately:
     # Run the development reverse proxy
     bin/grouper-ctl -vv user_proxy $USER@example.com
 

--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -17,6 +17,7 @@ from grouper.api.settings import settings
 from grouper.email import SendEmailThread
 from grouper.graph import GroupGraph
 from grouper.models import get_db_engine, Session, load_plugins
+from grouper.settings import default_settings_path
 from grouper.util import get_loglevel, get_database_url
 
 from sqlalchemy.exc import OperationalError
@@ -56,7 +57,7 @@ class DbRefreshThread(Thread):
 def main(argv):
 
     parser = argparse.ArgumentParser(description="Grouper Web Server.")
-    parser.add_argument("-c", "--config", default="/etc/grouper.yaml",
+    parser.add_argument("-c", "--config", default=default_settings_path(),
                         help="Path to config file.")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Increase logging verbosity.")

--- a/bin/grouper-ctl
+++ b/bin/grouper-ctl
@@ -19,7 +19,7 @@ from grouper.capabilities import Capabilities
 from grouper.constants import SYSTEM_PERMISSIONS
 from grouper.graph import GroupGraph
 from grouper.oneoff import BaseOneOff
-from grouper.settings import settings
+from grouper.settings import settings, default_settings_path
 from grouper.util import get_loglevel
 
 
@@ -222,7 +222,7 @@ def main():
     description_msg = "Grouper Control"
     parser = argparse.ArgumentParser(description=description_msg)
 
-    parser.add_argument("-c", "--config", default="/etc/grouper.yaml",
+    parser.add_argument("-c", "--config", default=default_settings_path(),
                         help="Path to config file.")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Increase logging verbosity.")

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -19,6 +19,7 @@ import grouper.fe
 from grouper.fe.routes import HANDLERS
 from grouper.fe.util import get_template_env
 from grouper.fe.settings import settings
+from grouper.settings import default_settings_path
 
 from sqlalchemy.exc import OperationalError
 
@@ -57,7 +58,7 @@ class DbRefreshThread(Thread):
 def main(argv):
 
     parser = argparse.ArgumentParser(description="Grouper Web Server.")
-    parser.add_argument("-c", "--config", default="/etc/grouper.yaml",
+    parser.add_argument("-c", "--config", default=default_settings_path(),
                         help="Path to config file.")
     parser.add_argument("-v", "--verbose", action="count", default=0,
                         help="Increase logging verbosity.")

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import threading
 import time
@@ -80,6 +81,8 @@ class Settings(object):
             except KeyError as err:
                 raise AttributeError(err)
 
+def default_settings_path():
+    return os.environ.get("GROUPER_SETTINGS", "/etc/grouper.yaml")
 
 settings = Settings({
     "database": None,

--- a/runtests
+++ b/runtests
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-PYTHONPATH=. exec py.test -v "$@"

--- a/tools/README.rst
+++ b/tools/README.rst
@@ -1,0 +1,3 @@
+This directory contains scripts useful for development, but not for end-users.
+It will not be included in the distributions built by ``python setup.py sdist``
+and should not be used in Grouper deployments.

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+import optparse
+import subprocess
+import os
+import signal
+
+parser = optparse.OptionParser(r"""
+
+Starts the app listening on localhost, for local development.
+
+This script launches the various Tornado servers, then runs a reverse proxy
+which serves to the frontend.  After it's all up and running, browse to
+
+    http://localhost:8888/
+""")
+
+parser.add_option(
+    '--interface',
+    action='store', dest='interface',
+    default='127.0.0.1', help='Set the interface for the proxy to listen on'
+)
+parser.add_option(
+    '--user',
+    action='store', dest='user',
+    default='admin@example.com', help='Set the user for the proxy'
+)
+
+(options, args) = parser.parse_args()
+
+os.chdir(os.path.join(os.path.dirname(__file__), '..'))
+
+# Set up a new process group, so that we can later kill the servers
+# and all of the processes they spawn.
+os.setpgrp()
+
+settings = os.environ.get("GROUPER_SETTINGS", "config/dev.yaml")
+
+cmds = [
+    "bin/grouper-ctl -vvc {} user_proxy {}".format(
+        settings,
+        options.user,
+    ),
+    "bin/grouper-fe --config={}".format(settings),
+    "bin/grouper-api --config={}".format(settings),
+]
+
+for cmd in cmds:
+    subprocess.Popen(cmd, shell=True)
+
+try:
+    signal.pause()
+finally:
+    # Kill everything in our process group.
+    os.killpg(0, signal.SIGTERM)

--- a/tools/test-all
+++ b/tools/test-all
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pushd "$(dirname "$(dirname "$(readlink "$0")")")"
+
+PYTHONPATH=. exec py.test -v "$@"
+popd


### PR DESCRIPTION
This pull request defines a `GROUPER_SETTINGS` environment variable, which is used if `-c` is not passed to a script in `bin/`. Among other things, this has the advantage of making `README.rst` much more readable.

We also add a `tools/run-dev`, which automates starting up the various servers used for development.