### PR TITLE
Add mock to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ mrproxy==0.3.2
 py==1.4.20
 pytest==2.7.2
 coverage==3.7.1
+mock==1.3.0


### PR DESCRIPTION
Needed to run the test suite, which otherwise fails with:

```
________ ERROR collecting tests/test_fe_util.py _________
tests/test_fe_util.py:2: in <module>
>   from mock import patch
E   ImportError: No module named mock
```