### PR TITLE
Don't require AUDIT_MANAGER to complete an audit

### DIFF
--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -817,7 +817,7 @@ class GroupRequests(GrouperHandler):
 class AuditsComplete(GrouperHandler):
     def post(self, audit_id):
         user = self.get_current_user()
-        if not user.has_permission(AUDIT_MANAGER):
+        if not user.has_permission(PERMISSION_AUDITOR):
             return self.forbidden()
 
         audit = self.session.query(Audit).filter(Audit.id == audit_id).one()


### PR DESCRIPTION
Previously, we required ``AUDIT_MANAGER`` to complete the audit for a single group,
which means that normal auditors were unable to complete audits. Here, we
instead require that they have ``PERMISSION_AUDITOR``.

Manually verified. We need frontend tests.