### PR TITLE
fix modal to show key details on public key audit endpoint

### DIFF
--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -20,7 +20,7 @@
     </td>
 {%- endmacro %}
 
-{% macro public_key_panel(max_height, user, public_keys, can_control=False) -%}
+{% macro public_key_modal() -%}
     <div id="key-modal" class="modal fade">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -37,7 +37,10 @@
             </div>
         </div>
     </div>
+{%- endmacro %}
 
+{% macro public_key_panel(max_height, user, public_keys, can_control=False) -%}
+    {{ public_key_modal() }}
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">Public Keys</h3>

--- a/grouper/fe/templates/users-publickey.html
+++ b/grouper/fe/templates/users-publickey.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import account, paginator, one_public_key_row, dropdown with context %}
+{% from 'macros/ui.html' import account, paginator, public_key_modal, one_public_key_row, dropdown with context %}
 
 {% block heading %}
     {% if not form.enabled.data %}
@@ -74,4 +74,5 @@
         </table>
     </div>
 </div>
+{{ public_key_modal() }}
 {% endblock %}


### PR DESCRIPTION
forgot to render the markup for the modal, so doing that.