### PR TITLE
use fully qualified usernames per FE handler requirement

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,39 +14,39 @@ from util import add_member, grant_permission
 
 @pytest.fixture
 def standard_graph(session, graph, users, groups, permissions):
-    add_member(groups["team-sre"], users["gary"], role="owner")
-    add_member(groups["team-sre"], users["zay"])
-    add_member(groups["team-sre"], users["zorkian"])
+    add_member(groups["team-sre"], users["gary@a.co"], role="owner")
+    add_member(groups["team-sre"], users["zay@a.co"])
+    add_member(groups["team-sre"], users["zorkian@a.co"])
     grant_permission(groups["team-sre"], permissions["ssh"], argument="*")
 
-    add_member(groups["serving-team"], users["zorkian"], role="owner")
+    add_member(groups["serving-team"], users["zorkian@a.co"], role="owner")
     add_member(groups["serving-team"], groups["team-sre"])
     add_member(groups["serving-team"], groups["tech-ops"])
     grant_permission(groups["serving-team"], permissions["audited"])
 
-    add_member(groups["tech-ops"], users["zay"], role="owner")
-    add_member(groups["tech-ops"], users["gary"])
-    add_member(groups["tech-ops"], users["figurehead"], role="np-owner")
+    add_member(groups["tech-ops"], users["zay@a.co"], role="owner")
+    add_member(groups["tech-ops"], users["gary@a.co"])
+    add_member(groups["tech-ops"], users["figurehead@a.co"], role="np-owner")
     grant_permission(groups["tech-ops"], permissions["ssh"], argument="shell")
 
-    add_member(groups["security-team"], users["oliver"], role="owner")
-    add_member(groups["security-team"], users["figurehead"], role="member")
+    add_member(groups["security-team"], users["oliver@a.co"], role="owner")
+    add_member(groups["security-team"], users["figurehead@a.co"], role="member")
 
-    add_member(groups["sad-team"], users["zorkian"], role="owner")
-    add_member(groups["sad-team"], users["oliver"])
+    add_member(groups["sad-team"], users["zorkian@a.co"], role="owner")
+    add_member(groups["sad-team"], users["oliver@a.co"])
 
-    add_member(groups["audited-team"], users["zorkian"], role="owner")
+    add_member(groups["audited-team"], users["zorkian@a.co"], role="owner")
     grant_permission(groups["audited-team"], permissions["audited"])
 
-    add_member(groups["team-infra"], users["gary"], role="owner")
+    add_member(groups["team-infra"], users["gary@a.co"], role="owner")
     add_member(groups["team-infra"], groups["serving-team"])
     add_member(groups["team-infra"], groups["security-team"])
     grant_permission(groups["team-infra"], permissions["sudo"], argument="shell")
 
-    add_member(groups["auditors"], users["zorkian"], role="owner")
+    add_member(groups["auditors"], users["zorkian@a.co"], role="owner")
     grant_permission(groups["auditors"], permissions[PERMISSION_AUDITOR])
 
-    add_member(groups["all-teams"], users["testuser"], role="owner")
+    add_member(groups["all-teams"], users["testuser@a.co"], role="owner")
     add_member(groups["all-teams"], groups["team-infra"])
 
     session.commit()
@@ -84,9 +84,10 @@ def graph(session):
 def users(session):
     users = {
         username: User.get_or_create(session, username=username)[0]
-        for username in ("gary", "zay", "zorkian", "oliver", "testuser", "figurehead", "zebu")
+        for username in ("gary@a.co", "zay@a.co", "zorkian@a.co", "oliver@a.co", "testuser@a.co",
+                "figurehead@a.co", "zebu@a.co")
     }
-    users["role"] = User.get_or_create(session, username="role", role_user=True)[0]
+    users["role@a.co"] = User.get_or_create(session, username="role@a.co", role_user=True)[0]
     session.commit()
     return users
 

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -12,8 +12,10 @@ def test_users(users, http_client, base_url):
     api_url = url(base_url, '/users')
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
-    users_wo_role = sorted((u for u in users if u != u'role'))
+    users_wo_role = sorted((u for u in users if u != u"role@a.co"))
 
+    print 'user_wo_role={}'.format(users_wo_role)
+    print 'res={}'.format(sorted(body["data"]["users"]))
     assert resp.code == 200
     assert body["status"] == "ok"
     assert sorted(body["data"]["users"]) == users_wo_role

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -21,25 +21,25 @@ def test_group_audited(standard_graph, session, groups, permissions):  # noqa
 def test_user_is_auditor(standard_graph):  # noqa
     """ Ensure users get the ability to audit. """
 
-    assert user_is_auditor("zorkian")
-    assert not user_is_auditor("oliver")
+    assert user_is_auditor("zorkian@a.co")
+    assert not user_is_auditor("oliver@a.co")
 
 
 def test_assert_can_join(users, groups):  # noqa
     """ Test various audit constraints to ensure that users can/can't join as appropriate. """
 
     # Non-auditor can join non-audited group as owner.
-    assert assert_can_join(groups["team-infra"], users["zay"], role="owner")
+    assert assert_can_join(groups["team-infra"], users["zay@a.co"], role="owner")
 
     # Auditor can join non-audited group as owner.
-    assert assert_can_join(groups["team-infra"], users["zorkian"], role="owner")
+    assert assert_can_join(groups["team-infra"], users["zorkian@a.co"], role="owner")
 
     # Non-auditor can NOT join audited group as owner.
     with pytest.raises(UserNotAuditor):
-        assert not assert_can_join(groups["serving-team"], users["zay"], role="owner")
+        assert not assert_can_join(groups["serving-team"], users["zay@a.co"], role="owner")
 
     # Non-auditor can join audited group as member.
-    assert assert_can_join(groups["serving-team"], users["zay"])
+    assert assert_can_join(groups["serving-team"], users["zay@a.co"])
 
     # Group with non-auditor owner can NOT join audited group.
     with pytest.raises(UserNotAuditor):

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -4,17 +4,17 @@ from util import get_users, get_groups, add_member
 
 
 def setup_desc_to_ances(session, users, groups):  # noqa
-    add_member(groups["team-sre"], users["gary"], role="owner")
-    add_member(groups["team-sre"], users["zay"])
+    add_member(groups["team-sre"], users["gary@a.co"], role="owner")
+    add_member(groups["team-sre"], users["zay@a.co"])
 
-    add_member(groups["tech-ops"], users["zay"], role="owner")
-    add_member(groups["tech-ops"], users["gary"])
+    add_member(groups["tech-ops"], users["zay@a.co"], role="owner")
+    add_member(groups["tech-ops"], users["gary@a.co"])
 
-    add_member(groups["team-infra"], users["gary"], role="owner")
+    add_member(groups["team-infra"], users["gary@a.co"], role="owner")
     add_member(groups["team-infra"], groups["team-sre"])
     add_member(groups["team-infra"], groups["tech-ops"])
 
-    add_member(groups["all-teams"], users["testuser"], role="owner")
+    add_member(groups["all-teams"], users["testuser@a.co"], role="owner")
     add_member(groups["all-teams"], groups["team-infra"])
 
 
@@ -25,61 +25,63 @@ def test_graph_desc_to_ances(session, graph, users, groups):  # noqa
     session.commit()
     graph.update_from_db(session)
 
-    assert get_users(graph, "team-sre") == set(["gary", "zay"])
-    assert get_users(graph, "tech-ops") == set(["gary", "zay"])
+    assert get_users(graph, "team-sre") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "tech-ops") == set(["gary@a.co", "zay@a.co"])
 
-    assert get_users(graph, "team-infra") == set(["gary", "zay"])
-    assert get_users(graph, "team-infra", cutoff=1) == set(["gary"])
+    assert get_users(graph, "team-infra") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "team-infra", cutoff=1) == set(["gary@a.co"])
 
-    assert get_users(graph, "all-teams") == set(["gary", "zay", "testuser"])
-    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser"])
+    assert get_users(graph, "all-teams") == set(["gary@a.co", "zay@a.co", "testuser@a.co"])
+    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser@a.co"])
 
-    assert get_groups(graph, "gary") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
-    assert get_groups(graph, "gary", cutoff=1) == set(["team-sre", "tech-ops", "team-infra"])
+    assert get_groups(graph, "gary@a.co") == set(["team-sre", "all-teams", "tech-ops",
+            "team-infra"])
+    assert get_groups(graph, "gary@a.co", cutoff=1) == set(["team-sre", "tech-ops", "team-infra"])
 
-    assert get_groups(graph, "zay") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
-    assert get_groups(graph, "zay", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "zay@a.co") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
+    assert get_groups(graph, "zay@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "testuser") == set(["all-teams"])
-    assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co") == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co", cutoff=1) == set(["all-teams"])
 
 
 def test_graph_add_member_existing(session, graph, users, groups):  # noqa
     """ Test adding members to an existing relationship."""
 
-    add_member(groups["team-sre"], users["gary"], role="owner")
-    add_member(groups["tech-ops"], users["gary"], role="owner")
+    add_member(groups["team-sre"], users["gary@a.co"], role="owner")
+    add_member(groups["tech-ops"], users["gary@a.co"], role="owner")
 
-    add_member(groups["team-infra"], users["gary"], role="owner")
+    add_member(groups["team-infra"], users["gary@a.co"], role="owner")
     add_member(groups["team-infra"], groups["team-sre"])
     add_member(groups["team-infra"], groups["tech-ops"])
 
-    add_member(groups["all-teams"], users["testuser"], role="owner")
+    add_member(groups["all-teams"], users["testuser@a.co"], role="owner")
     add_member(groups["all-teams"], groups["team-infra"])
 
-    add_member(groups["team-sre"], users["zay"])
-    add_member(groups["tech-ops"], users["zay"])
+    add_member(groups["team-sre"], users["zay@a.co"])
+    add_member(groups["tech-ops"], users["zay@a.co"])
 
     session.commit()
     graph.update_from_db(session)
 
-    assert get_users(graph, "team-sre") == set(["gary", "zay"])
-    assert get_users(graph, "tech-ops") == set(["gary", "zay"])
+    assert get_users(graph, "team-sre") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "tech-ops") == set(["gary@a.co", "zay@a.co"])
 
-    assert get_users(graph, "team-infra") == set(["gary", "zay"])
-    assert get_users(graph, "team-infra", cutoff=1) == set(["gary"])
+    assert get_users(graph, "team-infra") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "team-infra", cutoff=1) == set(["gary@a.co"])
 
-    assert get_users(graph, "all-teams") == set(["gary", "zay", "testuser"])
-    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser"])
+    assert get_users(graph, "all-teams") == set(["gary@a.co", "zay@a.co", "testuser@a.co"])
+    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser@a.co"])
 
-    assert get_groups(graph, "gary") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
-    assert get_groups(graph, "gary", cutoff=1) == set(["team-sre", "tech-ops", "team-infra"])
+    assert get_groups(graph, "gary@a.co") == set(["team-sre", "all-teams", "tech-ops",
+            "team-infra"])
+    assert get_groups(graph, "gary@a.co", cutoff=1) == set(["team-sre", "tech-ops", "team-infra"])
 
-    assert get_groups(graph, "zay") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
-    assert get_groups(graph, "zay", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "zay@a.co") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
+    assert get_groups(graph, "zay@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "testuser") == set(["all-teams"])
-    assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co") == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co", cutoff=1) == set(["all-teams"])
 
 
 def test_graph_with_removes(session, graph, users, groups):  # noqa
@@ -87,92 +89,93 @@ def test_graph_with_removes(session, graph, users, groups):  # noqa
 
     setup_desc_to_ances(session, users, groups)
 
-    groups["team-infra"].revoke_member(users["gary"], users["gary"], "Unit Testing")
+    groups["team-infra"].revoke_member(users["gary@a.co"], users["gary@a.co"], "Unit Testing")
     session.commit()
     graph.update_from_db(session)
-    assert get_users(graph, "team-sre") == set(["gary", "zay"])
-    assert get_users(graph, "tech-ops") == set(["gary", "zay"])
+    assert get_users(graph, "team-sre") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "tech-ops") == set(["gary@a.co", "zay@a.co"])
 
-    assert get_users(graph, "team-infra") == set(["gary", "zay"])
+    assert get_users(graph, "team-infra") == set(["gary@a.co", "zay@a.co"])
     assert get_users(graph, "team-infra", cutoff=1) == set()
 
-    assert get_users(graph, "all-teams") == set(["gary", "zay", "testuser"])
-    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser"])
+    assert get_users(graph, "all-teams") == set(["gary@a.co", "zay@a.co", "testuser@a.co"])
+    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser@a.co"])
 
-    assert get_groups(graph, "gary") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
-    assert get_groups(graph, "gary", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "gary@a.co") == set(["team-sre", "all-teams", "tech-ops",
+        "team-infra"])
+    assert get_groups(graph, "gary@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "zay") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
-    assert get_groups(graph, "zay", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "zay@a.co") == set(["team-sre", "all-teams", "tech-ops", "team-infra"])
+    assert get_groups(graph, "zay@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "testuser") == set(["all-teams"])
-    assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co") == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co", cutoff=1) == set(["all-teams"])
 
-    groups["all-teams"].revoke_member(users["gary"], groups["team-infra"], "Unit Testing")
+    groups["all-teams"].revoke_member(users["gary@a.co"], groups["team-infra"], "Unit Testing")
     session.commit()
     graph.update_from_db(session)
-    assert get_users(graph, "team-sre") == set(["gary", "zay"])
-    assert get_users(graph, "tech-ops") == set(["gary", "zay"])
+    assert get_users(graph, "team-sre") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "tech-ops") == set(["gary@a.co", "zay@a.co"])
 
-    assert get_users(graph, "team-infra") == set(["gary", "zay"])
+    assert get_users(graph, "team-infra") == set(["gary@a.co", "zay@a.co"])
     assert get_users(graph, "team-infra", cutoff=1) == set([])
 
-    assert get_users(graph, "all-teams") == set(["testuser"])
-    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser"])
+    assert get_users(graph, "all-teams") == set(["testuser@a.co"])
+    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser@a.co"])
 
-    assert get_groups(graph, "gary") == set(["team-sre", "tech-ops", "team-infra"])
-    assert get_groups(graph, "gary", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "gary@a.co") == set(["team-sre", "tech-ops", "team-infra"])
+    assert get_groups(graph, "gary@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "zay") == set(["team-sre", "tech-ops", "team-infra"])
-    assert get_groups(graph, "zay", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "zay@a.co") == set(["team-sre", "tech-ops", "team-infra"])
+    assert get_groups(graph, "zay@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "testuser") == set(["all-teams"])
-    assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co") == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co", cutoff=1) == set(["all-teams"])
 
-    groups["team-infra"].revoke_member(users["gary"], groups["tech-ops"], "Unit Testing")
+    groups["team-infra"].revoke_member(users["gary@a.co"], groups["tech-ops"], "Unit Testing")
     session.commit()
     graph.update_from_db(session)
-    assert get_users(graph, "team-sre") == set(["gary", "zay"])
-    assert get_users(graph, "tech-ops") == set(["gary", "zay"])
+    assert get_users(graph, "team-sre") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "tech-ops") == set(["gary@a.co", "zay@a.co"])
 
-    assert get_users(graph, "team-infra") == set(["gary", "zay"])
+    assert get_users(graph, "team-infra") == set(["gary@a.co", "zay@a.co"])
     assert get_users(graph, "team-infra", cutoff=1) == set([])
 
-    assert get_users(graph, "all-teams") == set(["testuser"])
-    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser"])
+    assert get_users(graph, "all-teams") == set(["testuser@a.co"])
+    assert get_users(graph, "all-teams", cutoff=1) == set(["testuser@a.co"])
 
-    assert get_groups(graph, "gary") == set(["team-sre", "tech-ops", "team-infra"])
-    assert get_groups(graph, "gary", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "gary@a.co") == set(["team-sre", "tech-ops", "team-infra"])
+    assert get_groups(graph, "gary@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "zay") == set(["team-sre", "tech-ops", "team-infra"])
-    assert get_groups(graph, "zay", cutoff=1) == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "zay@a.co") == set(["team-sre", "tech-ops", "team-infra"])
+    assert get_groups(graph, "zay@a.co", cutoff=1) == set(["team-sre", "tech-ops"])
 
-    assert get_groups(graph, "testuser") == set(["all-teams"])
-    assert get_groups(graph, "testuser", cutoff=1) == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co") == set(["all-teams"])
+    assert get_groups(graph, "testuser@a.co", cutoff=1) == set(["all-teams"])
 
 
 def test_graph_cycle_direct(session, graph, users, groups):  # noqa
     """ Test adding members where all descendants already exist."""
 
-    add_member(groups["team-sre"], users["gary"])
-    add_member(groups["tech-ops"], users["zay"])
+    add_member(groups["team-sre"], users["gary@a.co"])
+    add_member(groups["tech-ops"], users["zay@a.co"])
 
     add_member(groups["team-sre"], groups["tech-ops"])
     add_member(groups["tech-ops"], groups["team-sre"])
 
     session.commit()
     graph.update_from_db(session)
-    assert get_users(graph, "team-sre") == set(["gary", "zay"])
-    assert get_users(graph, "team-sre", cutoff=1) == set(["gary"])
+    assert get_users(graph, "team-sre") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "team-sre", cutoff=1) == set(["gary@a.co"])
 
-    assert get_users(graph, "tech-ops") == set(["gary", "zay"])
-    assert get_users(graph, "tech-ops", cutoff=1) == set(["zay"])
+    assert get_users(graph, "tech-ops") == set(["gary@a.co", "zay@a.co"])
+    assert get_users(graph, "tech-ops", cutoff=1) == set(["zay@a.co"])
 
-    assert get_groups(graph, "gary") == set(["team-sre", "tech-ops"])
-    assert get_groups(graph, "gary", cutoff=1) == set(["team-sre"])
+    assert get_groups(graph, "gary@a.co") == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "gary@a.co", cutoff=1) == set(["team-sre"])
 
-    assert get_groups(graph, "zay") == set(["team-sre", "tech-ops"])
-    assert get_groups(graph, "zay", cutoff=1) == set(["tech-ops"])
+    assert get_groups(graph, "zay@a.co") == set(["team-sre", "tech-ops"])
+    assert get_groups(graph, "zay@a.co", cutoff=1) == set(["tech-ops"])
 
 
 def test_graph_cycle_indirect(session, graph, users, groups):  # noqa
@@ -187,9 +190,9 @@ def test_graph_cycle_indirect(session, graph, users, groups):  # noqa
 
     """
 
-    add_member(groups["team-sre"], users["gary"])
-    add_member(groups["tech-ops"], users["zay"])
-    add_member(groups["team-infra"], users["testuser"])
+    add_member(groups["team-sre"], users["gary@a.co"])
+    add_member(groups["tech-ops"], users["zay@a.co"])
+    add_member(groups["team-infra"], users["testuser@a.co"])
 
     add_member(groups["team-sre"], groups["tech-ops"])
     add_member(groups["tech-ops"], groups["team-infra"])
@@ -199,26 +202,26 @@ def test_graph_cycle_indirect(session, graph, users, groups):  # noqa
 
     session.commit()
     graph.update_from_db(session)
-    all_users = set(["gary", "zay", "testuser"])
+    all_users = set(["gary@a.co", "zay@a.co", "testuser@a.co"])
     all_groups = set(["team-sre", "all-teams", "tech-ops", "team-infra"])
 
     assert get_users(graph, "team-sre") == all_users
-    assert get_users(graph, "team-sre", cutoff=1) == set(["gary"])
+    assert get_users(graph, "team-sre", cutoff=1) == set(["gary@a.co"])
 
     assert get_users(graph, "tech-ops") == all_users
-    assert get_users(graph, "tech-ops", cutoff=1) == set(["zay"])
+    assert get_users(graph, "tech-ops", cutoff=1) == set(["zay@a.co"])
 
     assert get_users(graph, "team-infra") == all_users
-    assert get_users(graph, "team-infra", cutoff=1) == set(["testuser"])
+    assert get_users(graph, "team-infra", cutoff=1) == set(["testuser@a.co"])
 
     assert get_users(graph, "all-teams") == all_users
     assert get_users(graph, "all-teams", cutoff=1) == set([])
 
-    assert get_groups(graph, "gary") == all_groups
-    assert get_groups(graph, "gary", cutoff=1) == set(["team-sre"])
+    assert get_groups(graph, "gary@a.co") == all_groups
+    assert get_groups(graph, "gary@a.co", cutoff=1) == set(["team-sre"])
 
-    assert get_groups(graph, "zay") == all_groups
-    assert get_groups(graph, "zay", cutoff=1) == set(["tech-ops"])
+    assert get_groups(graph, "zay@a.co") == all_groups
+    assert get_groups(graph, "zay@a.co", cutoff=1) == set(["tech-ops"])
 
-    assert get_groups(graph, "testuser") == all_groups
-    assert get_groups(graph, "testuser", cutoff=1) == set(["team-infra"])
+    assert get_groups(graph, "testuser@a.co") == all_groups
+    assert get_groups(graph, "testuser@a.co", cutoff=1) == set(["team-infra"])

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -24,14 +24,14 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
     assert sorted(get_group_permissions(graph, "team-infra")) == ["sudo:shell"]
     assert sorted(get_group_permissions(graph, "all-teams")) == []
 
-    assert sorted(get_user_permissions(graph, "gary")) == [
+    assert sorted(get_user_permissions(graph, "gary@a.co")) == [
         "audited:", "ssh:*", "ssh:shell", "sudo:shell"]
-    assert sorted(get_user_permissions(graph, "zay")) == [
+    assert sorted(get_user_permissions(graph, "zay@a.co")) == [
         "audited:", "ssh:*", "ssh:shell", "sudo:shell"]
-    assert sorted(get_user_permissions(graph, "zorkian")) == [
+    assert sorted(get_user_permissions(graph, "zorkian@a.co")) == [
         "audited:", PERMISSION_AUDITOR + ":", "ssh:*", "sudo:shell"]
-    assert sorted(get_user_permissions(graph, "testuser")) == []
-    assert sorted(get_user_permissions(graph, "figurehead")) == [
+    assert sorted(get_user_permissions(graph, "testuser@a.co")) == []
+    assert sorted(get_user_permissions(graph, "figurehead@a.co")) == [
         "sudo:shell"]
 
 
@@ -39,16 +39,16 @@ def test_has_permission(standard_graph, users):  # noqa
     """ Tests the has_permission method of a user object. """
 
     # In our setup, zorkian has 'audited' with no arguments
-    assert users["zorkian"].has_permission("audited"), "zorkian has permission audited"
-    assert not users["zorkian"].has_permission("audited", argument='foo'), \
+    assert users["zorkian@a.co"].has_permission("audited"), "zorkian has permission audited"
+    assert not users["zorkian@a.co"].has_permission("audited", argument='foo'), \
         "zorkian has permission audited:foo"
-    assert not users["zorkian"].has_permission("audited", argument='*'), \
+    assert not users["zorkian@a.co"].has_permission("audited", argument='*'), \
         "zorkian has permission audited:*"
 
     # zay has ssh:*
-    assert users["zay"].has_permission("ssh"), "zay has permission ssh"
-    assert users["zay"].has_permission("ssh", argument='foo'), "zay has permission ssh:foo"
-    assert users["zay"].has_permission("ssh", argument='*'), "zay has permission ssh:*"
+    assert users["zay@a.co"].has_permission("ssh"), "zay has permission ssh"
+    assert users["zay@a.co"].has_permission("ssh", argument='foo'), "zay has permission ssh:foo"
+    assert users["zay@a.co"].has_permission("ssh", argument='*'), "zay has permission ssh:*"
 
 
 class PermissionTests(unittest.TestCase):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -10,7 +10,7 @@ def test_basic_request(graph, groups, permissions, session, standard_graph, user
     assert not any([group.my_requests(status="pending").all() for group in groups.values()]), \
             "no group should start with pending requests"
 
-    group_sre.add_member(users["testuser"], users["testuser"], reason="for the lulz")
+    group_sre.add_member(users["testuser@a.co"], users["testuser@a.co"], reason="for the lulz")
     session.commit()
 
     request_not_sre = [group.my_requests(status="pending").all() for group in group_not_sre]
@@ -19,23 +19,25 @@ def test_basic_request(graph, groups, permissions, session, standard_graph, user
     assert len(request_sre) == 1, "affected group should have request"
 
     request = session.query(Request).filter_by(id=request_sre[0].id).scalar()
-    request.update_status(users["gary"], "actioned", "for being a good person")
+    request.update_status(users["gary@a.co"], "actioned", "for being a good person")
     session.commit()
 
     assert not any([group.my_requests(status="pending").all() for group in groups.values()]), \
             "no group should have requests after being actioned"
 
 def test_aggregate_request(graph, groups, permissions, session, standard_graph, users):
-    gary = users["gary"]
-    testuser = users["testuser"]
-    not_involved = [user for name,user in users.items() if name not in ("gary","testuser")]
+    gary = users["gary@a.co"]
+    testuser = users["testuser@a.co"]
+    not_involved = [user for name,user in users.items() if name not in ("gary@a.co",
+            "testuser@a.co")]
 
     print "users! {}".format(users.values())
     assert not any([u.my_requests_aggregate().all() for u in users.values()]), \
             "should have no pending requests to begin with"
 
     # one request to one team
-    groups["team-sre"].add_member(users["testuser"], users["testuser"], reason="for the lulz")
+    groups["team-sre"].add_member(users["testuser@a.co"], users["testuser@a.co"],
+            reason="for the lulz")
     session.commit()
 
     assert len(gary.my_requests_aggregate().all()) == 1, "one pending request for owner"
@@ -43,7 +45,8 @@ def test_aggregate_request(graph, groups, permissions, session, standard_graph, 
             "no pending requests if you're not the owner"
 
     # two request to two teams, same owner
-    groups["team-infra"].add_member(users["testuser"], users["testuser"], reason="for the lulz")
+    groups["team-infra"].add_member(users["testuser@a.co"], users["testuser@a.co"],
+            reason="for the lulz")
     session.commit()
 
     request_gary = gary.my_requests_aggregate().all()
@@ -53,7 +56,7 @@ def test_aggregate_request(graph, groups, permissions, session, standard_graph, 
 
     # resolving one request should reflect
     request = session.query(Request).filter_by(id=request_gary[0].id).scalar()
-    request.update_status(users["gary"], "actioned", "for being a good person")
+    request.update_status(users["gary@a.co"], "actioned", "for being a good person")
     session.commit()
 
     assert len(gary.my_requests_aggregate().all()) == 1, "one pending request for owner"
@@ -61,10 +64,11 @@ def test_aggregate_request(graph, groups, permissions, session, standard_graph, 
             "no pending requests if you're not the owner"
 
     # requests to dependent teams should reflect apprpriately
-    groups["security-team"].add_member(users["testuser"], users["testuser"], reason="for the lulz")
+    groups["security-team"].add_member(users["testuser@a.co"], users["testuser@a.co"],
+            reason="for the lulz")
     session.commit()
 
     assert len(gary.my_requests_aggregate().all()) == 1, "super owner should not get request"
-    assert len(users["oliver"].my_requests_aggregate().all()) == 1, "owner should get request"
-    user_not_gary_oliver = [u for n,u in users.items() if n not in ("gary","oliver")]
+    assert len(users["oliver@a.co"].my_requests_aggregate().all()) == 1, "owner should get request"
+    user_not_gary_oliver = [u for n,u in users.items() if n not in ("gary@a.co","oliver@a.co")]
     assert not any([u.my_requests_aggregate().all() for u in user_not_gary_oliver])

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -6,30 +6,30 @@ def test_basic_metadata(standard_graph, session, users, groups, permissions):  #
 
     graph = standard_graph  # noqa
 
-    assert len(users["zorkian"].my_metadata()) == 0, "No metadata yet"
+    assert len(users["zorkian@a.co"].my_metadata()) == 0, "No metadata yet"
 
     # Test setting "foo" to 1 works, and we get "1" back (metadata is defined as strings)
-    users["zorkian"].set_metadata("foo", 1)
-    md = users["zorkian"].my_metadata()
+    users["zorkian@a.co"].set_metadata("foo", 1)
+    md = users["zorkian@a.co"].my_metadata()
     assert len(md) == 1, "One metadata item"
     assert [d.data_value for d in md if d.data_key == "foo"] == ["1"], "foo is 1"
 
-    users["zorkian"].set_metadata("bar", "test string")
-    md = users["zorkian"].my_metadata()
+    users["zorkian@a.co"].set_metadata("bar", "test string")
+    md = users["zorkian@a.co"].my_metadata()
     assert len(md) == 2, "Two metadata items"
     assert [d.data_value for d in md if d.data_key == "bar"] == ["test string"], \
         "bar is test string"
 
-    users["zorkian"].set_metadata("foo", "test2")
-    md = users["zorkian"].my_metadata()
+    users["zorkian@a.co"].set_metadata("foo", "test2")
+    md = users["zorkian@a.co"].my_metadata()
     assert len(md) == 2, "Two metadata items"
     assert [d.data_value for d in md if d.data_key == "foo"] == ["test2"], "foo is test2"
 
-    users["zorkian"].set_metadata("foo", None)
-    md = users["zorkian"].my_metadata()
+    users["zorkian@a.co"].set_metadata("foo", None)
+    md = users["zorkian@a.co"].my_metadata()
     assert len(md) == 1, "One metadata item"
     assert [d.data_value for d in md if d.data_key == "foo"] == [], "foo is not found"
 
-    users["zorkian"].set_metadata("baz", None)
-    md = users["zorkian"].my_metadata()
+    users["zorkian@a.co"].set_metadata("baz", None)
+    md = users["zorkian@a.co"].my_metadata()
     assert len(md) == 1, "One metadata item"


### PR DESCRIPTION
since fully qualified usernames are enforced by `GrouperHandler.get_current_user()` test data in fixtures needs to follow suit in order to reuse that data in FE handler tests.

`sed -i` with some spot checking for line length. tests all pass locally.