### PR TITLE
Send email when group join requests are processed

### DIFF
--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -1224,6 +1224,20 @@ class GroupAdd(GrouperHandler):
                          member.name, form.data["role"]),
                      on_group_id=group.id)
 
+        if member.type == "User":
+            self.send_email(
+                [member.name],
+                'Added to group: {}'.format(group.name),
+                'request_actioned',
+                {
+                    'group': group.name,
+                    'actioned_by': self.current_user.name,
+                    'reason': form.data['reason'],
+                    'expiration': expiration,
+                    'role': form.data['role'],
+                }
+            )
+
         return self.redirect("/groups/{}?refresh=yes".format(group.name))
 
 

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -777,6 +777,36 @@ class GroupRequestUpdate(GrouperHandler):
                      'Updated request to status: {}'.format(form.data["status"]),
                      on_group_id=group.id, on_user_id=request.requester.id)
 
+        edge = self.session.query(GroupEdge).filter_by(
+            id=request.edge_id
+        ).one()
+        if form.data['status'] == 'actioned':
+            self.send_email(
+                [request.requester.name],
+                'Added to group: {}'.format(group.groupname),
+                'request_actioned',
+                {
+                    'group': group.name,
+                    'actioned_by': self.current_user.name,
+                    'reason': form.data['reason'],
+                    'expiration': edge.expiration,
+                    'role': edge.role,
+                }
+            )
+        elif form.data['status'] == 'cancelled':
+            self.send_email(
+                [request.requester.name],
+                'Request to join cancelled: {}'.format(group.groupname),
+                'request_cancelled',
+                {
+                    'group': group.name,
+                    'cancelled_by': self.current_user.name,
+                    'reason': form.data['reason'],
+                    'expiration': edge.expiration,
+                    'role': edge.role,
+                }
+            )
+
         # No explicit refresh because handler queries SQL.
         if form.data['redirect_aggregate']:
             return self.redirect("/user/requests")

--- a/grouper/fe/templates/email/request_actioned_html.tmpl
+++ b/grouper/fe/templates/email/request_actioned_html.tmpl
@@ -1,0 +1,19 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}Added to Group{% endblock %}
+
+{% block content %}
+
+<p>You have been added to the group
+<strong><a href="{{url}}/groups/{{requested}}">{{ group }}</a></strong>
+by {{ actioned_by }}.</p>
+
+<p>More details about the request:</p>
+
+<ul>
+    <li><strong>Role:</strong> {{ role }}</li>
+    <li><strong>Expiration:</strong> {{ expiration|expires_when_str }}</li>
+    <li><strong>Reason:</strong> {{ reason|escape }}</li>
+</ul>
+
+{% endblock %}

--- a/grouper/fe/templates/email/request_actioned_text.tmpl
+++ b/grouper/fe/templates/email/request_actioned_text.tmpl
@@ -1,0 +1,13 @@
+{% extends "email/base_text.tmpl" %}
+
+{% block subject %}Added to Group{% endblock %}
+
+{% block content %}
+You have been added to the group {{ group }} by {{ actioned_by }}.
+
+More details about the request:
+
+    Role: {{ role }}
+    Expiration: {{ expiration|expires_when_str }}
+    Reason: {{ reason }}
+{% endblock %}

--- a/grouper/fe/templates/email/request_cancelled_html.tmpl
+++ b/grouper/fe/templates/email/request_cancelled_html.tmpl
@@ -1,0 +1,20 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}Request Cancelled{% endblock %}
+
+{% block content %}
+
+<p>Your request to join the group
+<strong><a href="{{url}}/groups/{{requested}}">{{ group }}</a></strong>
+has been cancelled by {{ actioned_by }}.  The reason they gave was:</p>
+
+<blockquote><p>{{ reason|escape }}</p></blockquote>
+
+<p>More details about the request:</p>
+
+<ul>
+    <li><strong>Role:</strong> {{ role }}</li>
+    <li><strong>Expiration:</strong> {{ expiration|expires_when_str }}</li>
+</ul>
+
+{% endblock %}

--- a/grouper/fe/templates/email/request_cancelled_text.tmpl
+++ b/grouper/fe/templates/email/request_cancelled_text.tmpl
@@ -1,0 +1,15 @@
+{% extends "email/base_text.tmpl" %}
+
+{% block subject %}Request Cancelled{% endblock %}
+
+{% block content %}
+Your request to join the group {{ group }} has been cancelled by
+{{ cancelled_by }}.  The reason they gave was:
+
+    {{ reason }}
+
+More details about the request:
+
+    Role: {{ role }}
+    Expiration: {{ expiration|expires_when_str }}
+{% endblock %}


### PR DESCRIPTION
When a group join request has been either actioned or cancelled,
send email to the affected person letting them know and including
the reason field.  Assumes that the user name is an email address,
but that appears to be a common assumption in Grouper already.