### PR TITLE
Support a bind address for the FE and API servers

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -66,7 +66,10 @@ def main(argv):
     parser.add_argument("-V", "--version", action="version",
                         version="%%(prog)s %s" % grouper.__version__,
                         help="Display version information.")
-    parser.add_argument("-p", "--port", type=int, default=None, help="Override port in config.")
+    parser.add_argument("-a", "--address", type=str, default="",
+                        help="Override address in config.")
+    parser.add_argument("-p", "--port", type=int, default=None,
+                        help="Override port in config.")
     args = parser.parse_args()
     settings.start_config_thread(args.config, "api")
 
@@ -118,11 +121,12 @@ def main(argv):
     emailer.daemon = True
     emailer.start()
 
+    address = args.address or settings.address
     port = args.port or settings.port
 
     logging.info("Starting application server on port %d", port)
     server = tornado.httpserver.HTTPServer(application)
-    server.bind(port)
+    server.bind(port, address=address)
     server.start()
     try:
         tornado.ioloop.IOLoop.instance().start()

--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -66,7 +66,7 @@ def main(argv):
     parser.add_argument("-V", "--version", action="version",
                         version="%%(prog)s %s" % grouper.__version__,
                         help="Display version information.")
-    parser.add_argument("-a", "--address", type=str, default="",
+    parser.add_argument("-a", "--address", type=str, default=None,
                         help="Override address in config.")
     parser.add_argument("-p", "--port", type=int, default=None,
                         help="Override port in config.")

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -66,6 +66,8 @@ def main(argv):
     parser.add_argument("-V", "--version", action="version",
                         version="%%(prog)s %s" % grouper.__version__,
                         help="Display version information.")
+    parser.add_argument("-a", "--address", type=str, default="",
+                        help="Override address in config.")
     parser.add_argument("-p", "--port", type=int, default=None,
                         help="Override port in config.")
     parser.add_argument("-n", "--deployment-name", type=str, default="",
@@ -128,6 +130,7 @@ def main(argv):
     refresher.daemon = True
     refresher.start()
 
+    address = args.address or settings.address
     port = args.port or settings.port
 
     logging.info(
@@ -135,7 +138,7 @@ def main(argv):
         settings.num_processes, port
     )
     server = tornado.httpserver.HTTPServer(application)
-    server.bind(port)
+    server.bind(port, address=address)
     server.start(settings.num_processes)
     try:
         tornado.ioloop.IOLoop.instance().start()

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -66,7 +66,7 @@ def main(argv):
     parser.add_argument("-V", "--version", action="version",
                         version="%%(prog)s %s" % grouper.__version__,
                         help="Display version information.")
-    parser.add_argument("-a", "--address", type=str, default="",
+    parser.add_argument("-a", "--address", type=str, default=None,
                         help="Override address in config.")
     parser.add_argument("-p", "--port", type=int, default=None,
                         help="Override port in config.")

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -48,8 +48,8 @@ fe:
     # Type: int
     port: 8989
 
-    # The IP address to listen to requests on, or "" to listen on all
-    # addresses.
+    # The IP address to listen to requests on, or leave empty to listen to
+    # all addresses.
     # Type: str
     address: "127.0.0.1"
 
@@ -103,8 +103,8 @@ api:
     # Type: int
     port: 8990
 
-    # The IP address to listen to requests on, or "" to listen on all
-    # addresses.
+    # The IP address to listen to requests on, or leave empty to listen to
+    # all addresses.
     # Type: str
     address: "127.0.0.1"
 

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -48,6 +48,11 @@ fe:
     # Type: int
     port: 8989
 
+    # The IP address to listen to requests on, or "" to listen on all
+    # addresses.
+    # Type: str
+    address: "127.0.0.1"
+
     # All traps are stored in the database in UTC. This option chooses the
     # timezone for displaying datetime values.
     # Type: str
@@ -97,6 +102,11 @@ api:
     # The port to listen to requests on.
     # Type: int
     port: 8990
+
+    # The IP address to listen to requests on, or "" to listen on all
+    # addresses.
+    # Type: str
+    address: "127.0.0.1"
 
     # Passing debug option down tornado. Useful for development to
     # automatically reload code.

--- a/grouper/api/settings.py
+++ b/grouper/api/settings.py
@@ -4,6 +4,6 @@ from ..settings import Settings, settings as base_settings
 settings = Settings.from_settings(base_settings, {
     "debug": False,
     "port": 8990,
-    "address": "",
+    "address": None,
     "refresh_interval": 60,
 })

--- a/grouper/api/settings.py
+++ b/grouper/api/settings.py
@@ -4,5 +4,6 @@ from ..settings import Settings, settings as base_settings
 settings = Settings.from_settings(base_settings, {
     "debug": False,
     "port": 8990,
+    "address": "",
     "refresh_interval": 60,
 })

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -18,7 +18,7 @@ settings = FeSettings.from_settings(base_settings, {
     "debug": False,
     "num_processes": 1,
     "port": 8989,
-    "address": "",
+    "address": None,
     "timezone": FeSettings.default_timezone,
     "date_format": "%Y-%m-%d %I:%M %p",
     "cdnjs_prefix": "//cdnjs.cloudflare.com",

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -18,6 +18,7 @@ settings = FeSettings.from_settings(base_settings, {
     "debug": False,
     "num_processes": 1,
     "port": 8989,
+    "address": "",
     "timezone": FeSettings.default_timezone,
     "date_format": "%Y-%m-%d %I:%M %p",
     "cdnjs_prefix": "//cdnjs.cloudflare.com",


### PR DESCRIPTION
Add a command-line argument and configuration option to set the
bind address of the API and front-end servers.  Change the dev
configuration to bind both to localhost by default, rather than
listening to the public interfaces of development machines.