### PR TITLE
consolidate public addition logic and add simple end-to-end tests

### DIFF
--- a/bin/grouper-ctl
+++ b/bin/grouper-ctl
@@ -8,13 +8,13 @@ import BaseHTTPServer
 import code
 import getpass
 import logging
-import sshpubkey
 from mrproxy import UserProxyHandler
 from pprint import pprint
 from sqlalchemy.exc import IntegrityError
 
 import grouper
 from grouper import models
+from grouper import public_key
 from grouper.capabilities import Capabilities
 from grouper.constants import SYSTEM_PERMISSIONS
 from grouper.graph import GroupGraph
@@ -145,24 +145,13 @@ def user_command(args):
         print "Adding public key for user..."
 
         try:
-            pubkey = sshpubkey.PublicKey.from_str(args.public_key)
-        except sshpubkey.exc.PublicKeyParseError:
+            pubkey = public_key.add_public_key(session, user, args.public_key)
+        except public_key.DuplicateKey:
+            print "Key already in use."
+            return
+        except public_key.PublicKeyParseError:
             print "Public key appears to be invalid."
             return
-
-        db_pubkey = models.PublicKey(
-            user=user,
-            public_key='%s %s %s' % (pubkey.key_type, pubkey.key, pubkey.comment),
-            fingerprint=pubkey.fingerprint,
-        )
-        try:
-            db_pubkey.add(session)
-            session.flush()
-        except IntegrityError:
-            session.rollback()
-            print "Key is already in use. Public keys must be unique."
-            return
-        session.commit()
 
         models.AuditLog.log(session, user.id, 'add_public_key',
                             '(Administrative) Added public key: {}'.format(pubkey.fingerprint),

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -1,0 +1,37 @@
+from sqlalchemy.exc import IntegrityError
+import sshpubkey
+from sshpubkey.exc import PublicKeyParseError #noqa
+
+from .models import PublicKey
+
+
+class DuplicateKey(Exception):
+    pass
+
+def add_public_key(session, user, public_key_str):
+    """Add a public key for a particular user.
+
+    Args:
+        session: db session
+        user: User model of user in question
+        public_key_str: public key to add
+
+    Return created PublicKey model or raises DuplicateKey if key is already in use.
+    """
+    pubkey = sshpubkey.PublicKey.from_str(public_key_str)
+    db_pubkey = PublicKey(
+        user=user,
+        public_key='%s %s %s' % (pubkey.key_type, pubkey.key, pubkey.comment),
+        fingerprint=pubkey.fingerprint,
+        key_size=pubkey.key_size,
+        key_type=pubkey.key_type,
+    )
+    try:
+        db_pubkey.add(session)
+    except IntegrityError:
+        session.rollback()
+        raise DuplicateKey()
+
+    session.commit()
+
+    return db_pubkey

--- a/tests/test_fe_handlers.py
+++ b/tests/test_fe_handlers.py
@@ -1,17 +1,69 @@
 import json
+from urllib import urlencode
 
 import pytest
 from tornado.httpclient import HTTPError
 
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
 from fixtures import fe_app as app  # noqa
+from grouper import public_key
+from grouper.models import User
 from url_util import url
 
 
 @pytest.mark.gen_test
 def test_auth(users, http_client, base_url):
+    # no 'auth' present
     with pytest.raises(HTTPError):
         resp = yield http_client.fetch(base_url)
 
-        # TODO(herb): have a better story around UI testing
-        #resp = yield http_client.fetch(base_url, headers={'X-Grouper-User': 'zay'})
+    # invalid user
+    with pytest.raises(HTTPError):
+        resp = yield http_client.fetch(base_url, headers={'X-Grouper-User': 'nobody'})
+
+    # valid user
+    resp = yield http_client.fetch(base_url, headers={'X-Grouper-User': 'zorkian@a.co'})
+    assert resp.code == 200
+
+
+@pytest.mark.gen_test
+def test_public_key(session, users, http_client, base_url):
+    user = users['zorkian@a.co']
+    assert not user.my_public_keys()
+
+    good_key = ('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCUQeasspT/etEJR2WUoR+h2sMOQYbJgr0Q'
+            'E+J8p97gEhmz107KWZ+3mbOwyIFzfWBcJZCEg9wy5Paj+YxbGONqbpXAhPdVQ2TLgxr41bNXvbcR'
+            'AxZC+Q12UZywR4Klb2kungKz4qkcmSZzouaKK12UxzGB3xQ0N+3osKFj3xA1+B6HqrVreU19XdVo'
+            'AJh0xLZwhw17/NDM+dAcEdMZ9V89KyjwjraXtOVfFhQF0EDF0ame8d6UkayGrAiXC2He0P2Cja+J'
+            '371P27AlNLHFJij8WGxvcGGSeAxMLoVSDOOllLCYH5UieV8mNpX1kNe2LeA58ciZb0AXHaipSmCH'
+            'gh/ some-comment')
+
+    bad_key = 'ssh-rsa AAAblahblahkey some-comment'
+
+    # add it
+    fe_url = url(base_url, '/users/{}/public-key/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'public_key': good_key}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    # add bad key -- shouldn't add
+    fe_url = url(base_url, '/users/{}/public-key/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'public_key': bad_key}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = User.get(session, name=user.username)
+    keys = user.my_public_keys()
+    assert len(keys) == 1
+    assert keys[0].public_key == good_key
+
+    # delete it
+    fe_url = url(base_url, '/users/{}/public-key/{}/delete'.format(user.username, keys[0].id))
+    resp = yield http_client.fetch(fe_url, method="POST", body='',
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = User.get(session, name=user.username)
+    assert not user.my_public_keys()


### PR DESCRIPTION
apparently `grouper-ctl` uses a different implementation of the public key addition logic. :cry: 