### PR TITLE
Send notifications and log to audit log for expired edges

### DIFF
--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -1,4 +1,4 @@
-from constants import PERMISSION_AUDITOR
+from .constants import PERMISSION_AUDITOR
 
 from grouper.graph import Graph
 from grouper.models import Audit

--- a/grouper/background.py
+++ b/grouper/background.py
@@ -3,10 +3,11 @@ import logging
 from threading import Thread
 from time import sleep
 
+from sqlalchemy import and_
 from sqlalchemy.exc import OperationalError
 
-from grouper.email_util import process_async_emails
-from grouper.models import get_db_engine, Session
+from grouper.email_util import notify_edge_expiration, process_async_emails
+from grouper.models import get_db_engine, GroupEdge, Session
 from grouper.perf_profile import prune_old_traces
 from grouper.util import get_database_url
 
@@ -32,12 +33,44 @@ class BackgroundThread(Thread):
         if self.sentry_client:
             self.sentry_client.captureException()
 
+    def expire_edges(self, session):
+        """Mark expired edges as inactive and log to the audit log.
+
+        Edges are immediately excluded from the permission graph once they've
+        expired, but we also want to note the expiration in the audit log and send
+        an email notification.  This function finds all expired edges, logs the
+        expiration to the audit log, and sends a notification message.  It's meant
+        to be run from the background processing thread.
+
+        Args:
+            session (session): database session
+        """
+        now = datetime.utcnow()
+
+        # Pull the expired edges.
+        edges = session.query(GroupEdge).filter(
+            GroupEdge.active == True,
+            and_(
+                GroupEdge.expiration <= now,
+                GroupEdge.expiration != None
+            )
+        ).all()
+
+        # Expire each one.
+        for edge in edges:
+            notify_edge_expiration(self.settings, session, edge)
+            edge.active = False
+            session.commit()
+
     def run(self):
         while True:
-            logging.debug("Sending emails...")
             try:
                 session = Session()
+                logging.debug("Expiring edges....")
+                self.expire_edges(session)
+                logging.debug("Sending emails...")
                 process_async_emails(self.settings, session, datetime.utcnow())
+                logging.debug("Pruning old traces....")
                 prune_old_traces(session)
                 session.commit()
                 session.close()
@@ -48,5 +81,4 @@ class BackgroundThread(Thread):
             except:
                 self.capture_exception()
                 raise
-
             sleep(60)

--- a/grouper/fe/templates/email/expiration_html.tmpl
+++ b/grouper/fe/templates/email/expiration_html.tmpl
@@ -1,0 +1,12 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}expiration of membership in group '{{ group_name }}'{% endblock %}
+
+{% block content %}
+{% if member_is_user %}
+<p>Your membership has now expired.</p>
+
+{% else %}
+<p>The membership of '{{ member_name }}' in the group '{{ group_name }}' (of which you are an owner) has expired.</p>
+{% endif %}
+{% endblock %}

--- a/grouper/fe/templates/email/expiration_text.tmpl
+++ b/grouper/fe/templates/email/expiration_text.tmpl
@@ -1,0 +1,12 @@
+{% extends "email/base_text.tmpl" %}
+
+{% block subject %}expiration of membership in group '{{ group_name }}'{% endblock %}
+
+{% block content %}
+{% if member_is_user %}
+Your membership has now expired.
+{% else %}
+The membership of '{{ member_name }}' in the group '{{ group_name }}' (of
+which you are an owner) has expired.
+{% endif %}
+{% endblock %}

--- a/grouper/fe/templates/email/expiration_warning_html.tmpl
+++ b/grouper/fe/templates/email/expiration_warning_html.tmpl
@@ -7,6 +7,6 @@
 <p>Your membership is about to expire at {{ expiration|print_date }}</p>
 
 {% else %}
-<p>The membership of '{{ member_name }}' in the group '{{ group_name }}' (which you are an owner) is about to expire on {{ expiration|print_date }}.</p>
+<p>The membership of '{{ member_name }}' in the group '{{ group_name }}' (of which you are an owner) is about to expire on {{ expiration|print_date }}.</p>
 {% endif %}
 {% endblock %}

--- a/grouper/fe/templates/email/expiration_warning_text.tmpl
+++ b/grouper/fe/templates/email/expiration_warning_text.tmpl
@@ -6,7 +6,7 @@
 {% if member_is_user %}
 Your membership is about to expire at {{ expiration|print_date }}.
 {% else %}
-The membership of '{{ member_name }}' in the group '{{ group_name }}' (which
-you are an owner) is about to expire on {{ expiration|print_date }}.
+The membership of '{{ member_name }}' in the group '{{ group_name }}' (of
+which you are an owner) is about to expire on {{ expiration|print_date }}.
 {% endif %}
 {% endblock %}

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -3,7 +3,8 @@ import pytest
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
 
 from grouper.audit import (
-    assert_controllers_are_auditors, assert_can_join, user_is_auditor, UserNotAuditor
+    assert_controllers_are_auditors, assert_can_join, user_is_auditor,
+    UserNotAuditor
 )
 
 

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+import pytest
+
+from fixtures import graph, users, groups, session  # noqa
+from util import add_member
+
+from grouper.background import BackgroundThread
+from grouper.fe.settings import settings
+from grouper.models import AsyncNotification, AuditLog, GroupEdge
+
+
+@pytest.fixture
+def expired_graph(session, graph, groups, users):
+    now = datetime.utcnow()
+    add_member(groups["team-sre"], users["gary@a.co"], role="owner")
+    add_member(groups["team-sre"], users["zay@a.co"], expiration=now)
+    add_member(groups["serving-team"], users["zorkian@a.co"], role="owner")
+    add_member(groups["serving-team"], groups["team-sre"], expiration=now)
+    return graph
+
+
+def test_expire_edges(expired_graph, session):  # noqa
+    """ Test expiration auditing and notification. """
+    email = session.query(AsyncNotification).all()
+    assert email == []
+    for edge in session.query(GroupEdge).all():
+        assert edge.active == True
+
+    # Expire the edges.
+    background = BackgroundThread(settings, None)
+    background.expire_edges(session)
+
+    # Check that the edges are now marked as inactive.
+    edges = session.query(GroupEdge).filter(GroupEdge.expiration != None).all()
+    for edge in edges:
+        assert edge.active == False
+
+    # Check that we have two queued email messages.
+    #
+    # TODO(rra): It would be nice to check the contents as well.
+    email = session.query(AsyncNotification).all()
+    assert len(email) == 2
+
+    # Check that we have three audit log entries: one for the expired user and
+    # two for both "sides" of the expired group membership.
+    audits = AuditLog.get_entries(session, action="expired_from_group")
+    assert len(audits) == 3


### PR DESCRIPTION
Previously, expired edges were just excluded by SQL query but were
otherwise left untouched.  This meant that edge expiration was not
an actual event, so we didn't log anything to the audit log and didn't
send notification.

Add a background processing task that looks for all expired but active
edges and sends expiration notification, logs an audit log message,
and then deactivates the edge.

Before deployment, we'll need to run a one-time job to mark all existing
expired edges inactive.