### PR TITLE
Exclude disabled groups from permission mapped groups

### DIFF
--- a/grouper/models.py
+++ b/grouper/models.py
@@ -1586,6 +1586,7 @@ class Permission(Model):
         ).filter(
             Group.id == PermissionMap.group_id,
             PermissionMap.permission_id == self.id,
+            Group.enabled == True,
         )
         return results.all()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,14 @@
-from grouper.models import GROUP_EDGE_ROLES
+from fixtures import (
+    graph,
+    groups,
+    permissions,
+    session,
+    standard_graph,
+    users,
+)  # noqa
+
+from grouper.models import GROUP_EDGE_ROLES, Group, Permission
+
 
 def test_group_edge_roles_order_unchanged():
     # The order of the GROUP_EDGE_ROLES tuple matters:  new roles must be
@@ -8,3 +18,12 @@ def test_group_edge_roles_order_unchanged():
     assert GROUP_EDGE_ROLES.index("manager") == 1
     assert GROUP_EDGE_ROLES.index("owner") == 2
     assert GROUP_EDGE_ROLES.index("np-owner") == 3
+
+
+def test_permission_exclude_inactive(session, standard_graph):
+    """Ensure disabled groups are excluded from permission data."""
+    group = Group.get(session, name="team-sre")
+    permission = Permission.get(session, "ssh")
+    assert "team-sre" in [g[0] for g in permission.get_mapped_groups()]
+    group.disable()
+    assert "team-sre" not in [g[0] for g in permission.get_mapped_groups()]


### PR DESCRIPTION
The frontend route /permissions/<permission> was showing disabled
groups in the list of groups that had that permission, causing
confusion when people search for grouper.permission.grant.  Exclude
inactive groups from the mapped groups attached to a permission.