### PR TITLE
Store secret hash, rather than secret

### DIFF
--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -1716,8 +1716,7 @@ class UserTokenAdd(GrouperHandler):
             )
 
         try:
-            token = UserToken(name=form.data["name"], user=user)
-            token.add(self.session)
+            token, secret = UserToken(name=form.data["name"], user=user).add(self.session)
             self.session.commit()
         except IntegrityError:
             self.session.rollback()
@@ -1740,7 +1739,7 @@ class UserTokenAdd(GrouperHandler):
                 }
         send_email(self.session, [user.name], 'User token created', 'user_tokens_changed',
                 settings, email_context)
-        return self.render("user-token-created.html", token=token)
+        return self.render("user-token-created.html", token=token, secret=secret)
 
 
 class UserTokenDisable(GrouperHandler):

--- a/grouper/fe/templates/user-token-created.html
+++ b/grouper/fe/templates/user-token-created.html
@@ -18,7 +18,7 @@
             <p>Your token <code>{{token.name}}</code> has been successfully created. Provide the
                 following to
             the application that requested the token:</p>
-            <pre class="alert alert-danger">{{token}}:{{token.secret}}</pre>
+            <pre class="alert alert-danger">{{token}}:{{secret}}</pre>
             <p class="text-danger">This is the only time this information will be displayed.</p>
         </div>
     </div>

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -47,14 +47,13 @@ def test_basic_metadata(standard_graph, session, users, groups, permissions):  #
 def test_usertokens(standard_graph, session, users, groups, permissions):  # noqa
     user = users["zorkian@a.co"]
     assert len(user.tokens) == 0
-    tok = UserToken(
+    tok, secret = UserToken(
         user=user,
         name="Foo"
-    )
-    tok.add(session)
+    ).add(session)
     assert len(user.tokens) == 1
 
-    assert tok.check_secret(tok.secret)
+    assert tok.check_secret(secret)
     assert tok.check_secret("invalid") == False
 
     assert tok.enabled == True
@@ -62,7 +61,7 @@ def test_usertokens(standard_graph, session, users, groups, permissions):  # noq
     assert tok.enabled == False
     assert user.tokens[0].enabled == False
     assert UserToken.get(session, name="Foo", user=user).enabled == False
-    assert tok.check_secret(tok.secret) == False
+    assert tok.check_secret(secret) == False
 
 
 


### PR DESCRIPTION
`self.secret` is set to `None` by default. When `self.add()` is called, `self.secret` (not stored) is set to a randomly generated string, and the SHA256 of the secret is placed in `hashed_secret` (which is database-backed)

Afterwards, comparisons are performed by hashing the user-specified secret and comparing against the hashed secret in the database.