### PR TITLE
Support for granular user management permissions

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -36,6 +36,8 @@ GROUP_ADMIN = "grouper.admin.groups"
 AUDIT_SECURITY = "grouper.audit.security"
 AUDIT_MANAGER = "grouper.audit.manage"
 AUDIT_VIEWER = "grouper.audit.view"
+USER_DISABLE = "grouper.user.disable"
+USER_ENABLE = "grouper.user.enable"
 
 # Permissions that are always created and are reserved.
 SYSTEM_PERMISSIONS = [
@@ -48,6 +50,8 @@ SYSTEM_PERMISSIONS = [
     (AUDIT_SECURITY, "Ability to audit security related activity on the system."),
     (AUDIT_MANAGER, "Ability to start global audits and view audit status."),
     (AUDIT_VIEWER, "Ability to view audit results and status."),
+    (USER_ENABLE, "Ability to enable a disabled user."),
+    (USER_DISABLE, "Ability to disable an enabled user."),
 ]
 
 # Used to construct name tuples in notification engine.

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -12,16 +12,15 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {% if current_user.user_admin %}
-        {% if user.enabled %}
-            <button class="btn btn-danger" data-toggle="modal" data-target="#disableModal">
-                <i class="fa fa-minus"></i> Disable
-            </button>
-        {% elif not user.enabled %}
-            <button class="btn btn-warning" data-toggle="modal" data-target="#enableModal">
-                <i class="fa fa-plus"></i> Enable
-            </button>
-        {% endif %}
+
+    {% if user.enabled and can_disable %}
+        <button class="btn btn-danger" data-toggle="modal" data-target="#disableModal">
+            <i class="fa fa-minus"></i> Disable
+        </button>
+    {% elif not user.enabled and can_enable %}
+        <button class="btn btn-warning" data-toggle="modal" data-target="#enableModal">
+            <i class="fa fa-plus"></i> Enable
+        </button>
     {% endif %}
     {% if current_user.id == user.id %}
     <div class="btn-group">

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -144,7 +144,7 @@
                     <span aria-hidden="true">&times;</span>
                     <span class="sr-only">Close</span>
                 </button>
-                <h4 class="modal-title">Disable Group</h4>
+                <h4 class="modal-title">Disable User</h4>
            </div>
             <div class="modal-body">
                 <p>Are you sure you want to disable this user?</p>


### PR DESCRIPTION
Breaks out enable/disable into separate permissions, although the
`grouper.admin.user` permission still remains.

Also fix a typo in a modal that only we see :) 