### PR TITLE
Add list_users, enable and disable functionality to grouper-ctl

### DIFF
--- a/grouper/ctl/user.py
+++ b/grouper/ctl/user.py
@@ -10,7 +10,7 @@ def handle_command(args):
         session = make_session()
         all_users = get_all_users(session)
         for user in all_users:
-            user_enabled = "enabled" if user.is_enabled else "disabled"
+            user_enabled = "enabled" if user.enabled else "disabled"
             logging.info("{} has status {}".format(user.name, user_enabled))
         return
 
@@ -38,7 +38,7 @@ def user_command(args):
             user = User.get(session, name=username)
             if not user:
                 logging.info("{}: No such user. Doing nothing.".format(username))
-            elif not user.is_enabled:
+            elif not user.enabled:
                 logging.info("{}: User already disabled. Doing nothing.".format(username))
             else:
                 logging.info("{}: User found, disabling...".format(username))
@@ -51,7 +51,7 @@ def user_command(args):
             user = User.get(session, name=username)
             if not user:
                 logging.info("{}: No such user. Doing nothing.".format(username))
-            elif user.is_enabled:
+            elif user.enabled:
                 logging.info("{}: User not disabled. Doing nothing.".format(username))
             else:
                 logging.info("{}: User found, enabling...".format(username))
@@ -96,7 +96,7 @@ def add_parser(subparsers):
     user_parser.set_defaults(func=handle_command)
     user_subparser = user_parser.add_subparsers(dest="subcommand")
 
-    user_list_parser = user_subparser.add_parser(
+    user_subparser.add_parser(
         "list", help="List all users and their account statuses")
 
     user_create_parser = user_subparser.add_parser(

--- a/grouper/ctl/user.py
+++ b/grouper/ctl/user.py
@@ -4,12 +4,14 @@ from grouper import public_key
 from grouper.ctl.util import ensure_valid_username, make_session
 from grouper.models import AuditLog, User, get_all_users
 
+
 def list_users(args):
     session = make_session()
     all_users = get_all_users(session)
     for user in all_users:
         user_enabled = "enabled" if user.is_enabled else "disabled"
         logging.info("{} has status {}".format(user.name, user_enabled))
+
 
 @ensure_valid_username
 def user_command(args):

--- a/grouper/ctl/user.py
+++ b/grouper/ctl/user.py
@@ -5,12 +5,17 @@ from grouper.ctl.util import ensure_valid_username, make_session
 from grouper.models import AuditLog, User, get_all_users
 
 
-def list_users(args):
-    session = make_session()
-    all_users = get_all_users(session)
-    for user in all_users:
-        user_enabled = "enabled" if user.is_enabled else "disabled"
-        logging.info("{} has status {}".format(user.name, user_enabled))
+def handle_command(args):
+    if args.subcommand == "list":
+        session = make_session()
+        all_users = get_all_users(session)
+        for user in all_users:
+            user_enabled = "enabled" if user.is_enabled else "disabled"
+            logging.info("{} has status {}".format(user.name, user_enabled))
+        return
+
+    else:
+        user_command(args)
 
 
 @ensure_valid_username
@@ -86,14 +91,13 @@ def user_command(args):
 
 
 def add_parser(subparsers):
-    list_users_parser = subparsers.add_parser(
-        "list_users", help="List all users and their account statuses")
-    list_users_parser.set_defaults(func=list_users)
-
     user_parser = subparsers.add_parser(
         "user", help="Edit user")
-    user_parser.set_defaults(func=user_command)
+    user_parser.set_defaults(func=handle_command)
     user_subparser = user_parser.add_subparsers(dest="subcommand")
+
+    user_list_parser = user_subparser.add_parser(
+        "list", help="List all users and their account statuses")
 
     user_create_parser = user_subparser.add_parser(
         "create", help="Create a new user account")

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -253,6 +253,10 @@ class User(Model):
     def type(self):
         return "User"
 
+    @property
+    def is_enabled(self):
+        return self.enabled
+
     def __repr__(self):
         return "<%s: id=%s username=%s>" % (
             type(self).__name__, self.id, self.username)

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -253,10 +253,6 @@ class User(Model):
     def type(self):
         return "User"
 
-    @property
-    def is_enabled(self):
-        return self.enabled
-
     def __repr__(self):
         return "<%s: id=%s username=%s>" % (
             type(self).__name__, self.id, self.username)

--- a/tests/test_grouper_ctl.py
+++ b/tests/test_grouper_ctl.py
@@ -59,25 +59,25 @@ def test_user_status_changes(make_user_session, make_group_session, session, use
 
     # disable the account
     call_main('user', 'disable', username)
-    assert not User.get(session, name=username).is_enabled
+    assert not User.get(session, name=username).enabled
 
     # double disabling is a no-op
     call_main('user', 'disable', username)
-    assert not User.get(session, name=username).is_enabled
+    assert not User.get(session, name=username).enabled
 
     # re-enable the account, preserving memberships
     call_main('user', 'enable', '--preserve-membership', username)
-    assert User.get(session, name=username).is_enabled
+    assert User.get(session, name=username).enabled
     assert (u'User', username) in groups[groupname].my_members()
 
     # enabling an active account is a no-op
     call_main('user', 'enable', username)
-    assert User.get(session, name=username).is_enabled
+    assert User.get(session, name=username).enabled
 
     # disable and re-enable without the --preserve-membership flag
     call_main('user', 'disable', username)
     call_main('user', 'enable', username)
-    assert User.get(session, name=username).is_enabled
+    assert User.get(session, name=username).enabled
     assert (u'User', username) not in groups[groupname].my_members()
 
 @patch('grouper.ctl.user.make_session')

--- a/tests/test_grouper_ctl.py
+++ b/tests/test_grouper_ctl.py
@@ -165,6 +165,7 @@ def test_sync_db_default_group(make_session, session, users, groups):
         assert permission in admin_group_permission_names, \
                 "Expected permission missing: %s" % permission
 
+
 @patch('grouper.ctl.oneoff.load_plugins')
 @patch('grouper.ctl.oneoff.Annex')
 @patch('grouper.ctl.oneoff.make_session')

--- a/tests/test_grouper_ctl.py
+++ b/tests/test_grouper_ctl.py
@@ -45,6 +45,40 @@ def test_user_create(make_session, session, users):
     users = [User.get(session, name=u) for u in usernames_with_one_bad]
     assert not any(users), 'one bad seed means no users created'
 
+@patch('grouper.ctl.user.make_session')
+@patch('grouper.ctl.group.make_session')
+def test_user_status_changes(make_user_session, make_group_session, session, users, groups):
+    make_user_session.return_value = session
+    make_group_session.return_value = session
+
+    username = 'zorkian@a.co'
+    groupname = 'team-sre'
+
+    # add user to a group
+    call_main('group', 'add_member', '--member', groupname, username)
+
+    # disable the account
+    call_main('user', 'disable', username)
+    assert not User.get(session, name=username).is_enabled
+
+    # double disabling is a no-op
+    call_main('user', 'disable', username)
+    assert not User.get(session, name=username).is_enabled
+
+    # re-enable the account, preserving memberships
+    call_main('user', 'enable', '--preserve-membership', username)
+    assert User.get(session, name=username).is_enabled
+    assert (u'User', username) in groups[groupname].my_members()
+
+    # enabling an active account is a no-op
+    call_main('user', 'enable', username)
+    assert User.get(session, name=username).is_enabled
+
+    # disable and re-enable without the --preserve-membership flag
+    call_main('user', 'disable', username)
+    call_main('user', 'enable', username)
+    assert User.get(session, name=username).is_enabled
+    assert (u'User', username) not in groups[groupname].my_members()
 
 @patch('grouper.ctl.user.make_session')
 def test_user_public_key(make_session, session, users):
@@ -130,7 +164,6 @@ def test_sync_db_default_group(make_session, session, users, groups):
     for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
         assert permission in admin_group_permission_names, \
                 "Expected permission missing: %s" % permission
-
 
 @patch('grouper.ctl.oneoff.load_plugins')
 @patch('grouper.ctl.oneoff.Annex')


### PR DESCRIPTION
### New Subcommands

To list all users and their account status (enabled / disabled), run

`bin/grouper-ctl -vv user list`

The `enable` and `disable` subcommands use the same syntax as `create`. One or more usernames must be provided. 
```$> bin/grouper-ctl -vv user disable username [ username ... ]```
```$> bin/grouper-ctl -vv user disable username [ username ... ]```

`enable` also allows an additional `--preserve-membership` flag that reactivates a user without revoking their access to any groups. This flag is set once per command, and applies to all accounts being actioned.
```$> bin/grouper-ctl -vv user enable username [ username ... ] --preserve-membership```
