### PR TITLE
Allow admins to create tokens for role accounts

### DIFF
--- a/grouper/fe/handlers/user_token_add.py
+++ b/grouper/fe/handlers/user_token_add.py
@@ -1,4 +1,5 @@
 from sqlalchemy.exc import IntegrityError
+from grouper.constants import USER_ADMIN
 from grouper.email_util import send_email
 from grouper.fe.forms import UserTokenForm
 from grouper.fe.settings import settings
@@ -25,7 +26,9 @@ class UserTokenAdd(GrouperHandler):
         if not user:
             return self.notfound()
 
-        if user.name != self.current_user.name:
+        if user.name != self.current_user.name and not (
+                self.current_user.has_permission(USER_ADMIN) and user.role_user
+        ):
             return self.forbidden()
 
         form = UserTokenForm(self.request.arguments)


### PR DESCRIPTION
Allowing admins to create tokens for normal users creates a quick path to
escalate privledges that might not be noticed. However, for bot users, there's
no other way to create a token. (Unless you lie to the frontend about your
identity)

When role account support is fully-landed, this can go away; owners of role
accounts will be able to self-service manage their role accounts.