### PR TITLE
Make minor tweaks to the Public Key and Counter schemas to fix MySQL …

### DIFF
--- a/grouper/models/counter.py
+++ b/grouper/models/counter.py
@@ -8,7 +8,7 @@ class Counter(Model):
     __tablename__ = "counters"
 
     id = Column(Integer, primary_key=True)
-    name = Column(String, unique=True, nullable=False)
+    name = Column(String(length=255), unique=True, nullable=False)
     count = Column(Integer, nullable=False, default=0)
     last_modified = Column(DateTime, default=datetime.utcnow, nullable=False)
 

--- a/grouper/models/public_key.py
+++ b/grouper/models/public_key.py
@@ -15,6 +15,6 @@ class PublicKey(Model):
 
     key_type = Column(String(length=32))
     key_size = Column(Integer)
-    public_key = Column(Text, nullable=False, unique=True)
-    fingerprint = Column(String(length=64), nullable=False)
+    public_key = Column(Text, nullable=False)
+    fingerprint = Column(String(length=64), nullable=False, unique=True)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)


### PR DESCRIPTION
…support

Attempting to autogenerate the SQL tables using grouper-ctl sync_db fails on MySQL systems.
This is due to the lack of length for the name column of the Counter model (this field is
a String type which translates to a SQL VARCHAR, which must have a length for MySQL). We
simply add a sufficiently large length (255) to this column in order to resolve the issue.
Additionally, the public_key column (type Text) of the PublicKey model was marked as unique.
MySQL doesn't support unique constraints on columns that do not have a specified length, so
we remove the unique constraint on the public_key column and instead move it to the fingerprint
column, which does have a maximum length, and should also be unique.

Signed-off-by: Tyler O'Meara <tyleromeara@dropbox.com>