### PR TITLE
Add request update emails for group approvers

### DIFF
--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -3,7 +3,7 @@ from grouper.email_util import send_email
 from grouper.fe.forms import GroupRequestModifyForm
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler, Alert
-from grouper.model_soup import Group, GroupEdge, Request, GROUP_EDGE_ROLES
+from grouper.model_soup import Group, GroupEdge, Request
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 from grouper.models.audit_log import AuditLog
 
@@ -95,9 +95,8 @@ class GroupRequestUpdate(GrouperHandler):
 
         approver_mail_to = [
             user.name
-            for user in group.my_users()
-            if GROUP_EDGE_ROLES[user.role] in ("manager", "owner", "np-owner") and
-            user.name != self.current_user.name and user.name != request.requester.username
+            for user in group.my_approver_users()
+            if user.name != self.current_user.name and user.name != request.requester.username
         ]
 
         send_email(

--- a/grouper/fe/templates/email/approver_request_updated_html.tmpl
+++ b/grouper/fe/templates/email/approver_request_updated_html.tmpl
@@ -1,0 +1,18 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}Membership Request Updated{% endblock %}
+
+{% block content %}
+
+<p><strong><a href="{{url}}/users/{{requester}}">{{ requester }}</a></strong>'s request
+to join <strong><a href="{{url}}/groups/{{group}}">{{ group }}</a></strong> has been
+<strong>{{ status }}</strong> by <a href="{{url}}/users/{{changed_by}}">{{ changed_by }}</a>.
+
+<p>More details about the action:</p>
+
+<ul>
+    <li><strong>Role:</strong> {{ role }}</li>
+    <li><strong>Reason:</strong> {{ reason|escape }}</li>
+</ul>
+
+{% endblock %}

--- a/grouper/fe/templates/email/approver_request_updated_text.tmpl
+++ b/grouper/fe/templates/email/approver_request_updated_text.tmpl
@@ -1,0 +1,13 @@
+{% extends "email/base_text.tmpl" %}
+
+{% block subject %}Membership Request Updated{% endblock %}
+
+{% block content %}
+{{ requester }}'s request to join {{ group }} has been {{ status }} by {{ changed_by }}.
+
+More details about the update:
+
+    Role: {{ role }}
+    Reason: {{ reason|escape }}
+
+{% endblock %}

--- a/grouper/model_soup.py
+++ b/grouper/model_soup.py
@@ -66,7 +66,7 @@ GROUP_EDGE_ROLES = (
 )
 OWNER_ROLE_INDICES = set([GROUP_EDGE_ROLES.index("owner"), GROUP_EDGE_ROLES.index("np-owner")])
 APPROVER_ROLE_INDICIES = set([GROUP_EDGE_ROLES.index("owner"), GROUP_EDGE_ROLES.index("np-owner"),
-        GROUP_EDGE_ROLES.index("manager")])
+        GROUP_EDGE_ROLES.index("manager")])  # TODO: Fix spelling
 
 
 class CommentObjectMixin(object):
@@ -710,6 +710,16 @@ class Group(Model, CommentObjectMixin):
         ).all()
 
         return users
+
+    def my_approver_users(self):
+        # type: () -> List[User]
+        """Returns a list of all users in this group that are approvers.
+
+        Returns:
+            A list of all User objects that are approvers for this group.
+        """
+
+        return [user for user in self.my_users() if user.role in APPROVER_ROLE_INDICIES]
 
     def my_log_entries(self):
 


### PR DESCRIPTION
Whenever an approver updates a group request, grouper now alerts
all approvers for that group (except the approver who updated the
request) of the changed status of the request.