### PR TITLE
Fix group url typos in the request update email templates

### DIFF
--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -96,7 +96,7 @@ class GroupJoin(GrouperHandler):
             email_context = {
                     "requester": member.name,
                     "requested_by": self.current_user.name,
-                    "requested": group.name,
+                    "group_name": group.name,
                     "reason": form.data["reason"],
                     "expiration": expiration,
                     "role": form.data["role"],

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -107,7 +107,7 @@ class GroupRequestUpdate(GrouperHandler):
             "approver_request_updated",
             settings,
             {
-                'group': group.name,
+                'group_name': group.name,
                 'requester': request.requester.username,
                 'changed_by': self.current_user.name,
                 'status': form.data['status'],
@@ -124,7 +124,7 @@ class GroupRequestUpdate(GrouperHandler):
                 'request_actioned',
                 settings,
                 {
-                    'group': group.name,
+                    'group_name': group.name,
                     'actioned_by': self.current_user.name,
                     'reason': form.data['reason'],
                     'expiration': edge.expiration,
@@ -139,7 +139,7 @@ class GroupRequestUpdate(GrouperHandler):
                 'request_cancelled',
                 settings,
                 {
-                    'group': group.name,
+                    'group_name': group.name,
                     'cancelled_by': self.current_user.name,
                     'reason': form.data['reason'],
                     'expiration': edge.expiration,

--- a/grouper/fe/templates/email/approver_request_updated_html.tmpl
+++ b/grouper/fe/templates/email/approver_request_updated_html.tmpl
@@ -5,7 +5,7 @@
 {% block content %}
 
 <p><strong><a href="{{url}}/users/{{requester}}">{{ requester }}</a></strong>'s request
-to join <strong><a href="{{url}}/groups/{{group}}">{{ group }}</a></strong> has been
+to join <strong><a href="{{url}}/groups/{{group_name}}">{{ group_name }}</a></strong> has been
 <strong>{{ status }}</strong> by <a href="{{url}}/users/{{changed_by}}">{{ changed_by }}</a>.
 
 <p>More details about the action:</p>

--- a/grouper/fe/templates/email/approver_request_updated_text.tmpl
+++ b/grouper/fe/templates/email/approver_request_updated_text.tmpl
@@ -3,7 +3,7 @@
 {% block subject %}Membership Request Updated{% endblock %}
 
 {% block content %}
-{{ requester }}'s request to join {{ group }} has been {{ status }} by {{ changed_by }}.
+{{ requester }}'s request to join {{ group_name }} has been {{ status }} by {{ changed_by }}.
 
 More details about the update:
 

--- a/grouper/fe/templates/email/pending_request_html.tmpl
+++ b/grouper/fe/templates/email/pending_request_html.tmpl
@@ -5,8 +5,8 @@
 {% block content %}
 
 <p><strong><a href="{{url}}/users/{{requester}}">{{ requester }}</a></strong> has requested
-to join <strong><a href="{{url}}/groups/{{requested}}">{{ requested }}</a></strong>. To action
-this request, please visit the <a href="{{url}}/groups/{{requested}}/requests?status=pending">
+to join <strong><a href="{{url}}/groups/{{group_name}}">{{ group_name }}</a></strong>. To action
+this request, please visit the <a href="{{url}}/groups/{{group_name}}/requests?status=pending">
 pending requests</a> queue.</p>
 
 <p>More details about the request:</p>

--- a/grouper/fe/templates/email/pending_request_text.tmpl
+++ b/grouper/fe/templates/email/pending_request_text.tmpl
@@ -3,10 +3,10 @@
 {% block subject %}Membership Request{% endblock %}
 
 {% block content %}
-{{ requester }} has requested to join {{ requested }}. To action this request, please visit the
+{{ requester }} has requested to join {{ group_name }}. To action this request, please visit the
 pending requests queue:
 
-    {{url}}/groups/{{requested}}/requests?status=pending
+    {{url}}/groups/{{group_name}}/requests?status=pending
 
 More details about the request:
 

--- a/grouper/fe/templates/email/request_actioned_html.tmpl
+++ b/grouper/fe/templates/email/request_actioned_html.tmpl
@@ -5,7 +5,7 @@
 {% block content %}
 
 <p>You have been added to the group
-<strong><a href="{{url}}/groups/{{group}}">{{ group }}</a></strong>
+<strong><a href="{{url}}/groups/{{group_name}}">{{ group_name }}</a></strong>
 by {{ actioned_by }}.</p>
 
 <p>More details about the request:</p>

--- a/grouper/fe/templates/email/request_actioned_html.tmpl
+++ b/grouper/fe/templates/email/request_actioned_html.tmpl
@@ -5,7 +5,7 @@
 {% block content %}
 
 <p>You have been added to the group
-<strong><a href="{{url}}/groups/{{requested}}">{{ group }}</a></strong>
+<strong><a href="{{url}}/groups/{{group}}">{{ group }}</a></strong>
 by {{ actioned_by }}.</p>
 
 <p>More details about the request:</p>

--- a/grouper/fe/templates/email/request_actioned_text.tmpl
+++ b/grouper/fe/templates/email/request_actioned_text.tmpl
@@ -3,7 +3,7 @@
 {% block subject %}Added to Group{% endblock %}
 
 {% block content %}
-You have been added to the group {{ group }} by {{ actioned_by }}.
+You have been added to the group {{ group_name }} by {{ actioned_by }}.
 
 More details about the request:
 

--- a/grouper/fe/templates/email/request_cancelled_html.tmpl
+++ b/grouper/fe/templates/email/request_cancelled_html.tmpl
@@ -5,7 +5,7 @@
 {% block content %}
 
 <p>Your request to join the group
-<strong><a href="{{url}}/groups/{{group}}">{{ group }}</a></strong>
+<strong><a href="{{url}}/groups/{{group_name}}">{{ group_name }}</a></strong>
 has been cancelled by {{ actioned_by }}.  The reason they gave was:</p>
 
 <blockquote><p>{{ reason|escape }}</p></blockquote>

--- a/grouper/fe/templates/email/request_cancelled_html.tmpl
+++ b/grouper/fe/templates/email/request_cancelled_html.tmpl
@@ -5,7 +5,7 @@
 {% block content %}
 
 <p>Your request to join the group
-<strong><a href="{{url}}/groups/{{requested}}">{{ group }}</a></strong>
+<strong><a href="{{url}}/groups/{{group}}">{{ group }}</a></strong>
 has been cancelled by {{ actioned_by }}.  The reason they gave was:</p>
 
 <blockquote><p>{{ reason|escape }}</p></blockquote>

--- a/grouper/fe/templates/email/request_cancelled_text.tmpl
+++ b/grouper/fe/templates/email/request_cancelled_text.tmpl
@@ -3,7 +3,7 @@
 {% block subject %}Request Cancelled{% endblock %}
 
 {% block content %}
-Your request to join the group {{ group }} has been cancelled by
+Your request to join the group {{ group_name }} has been cancelled by
 {{ cancelled_by }}.  The reason they gave was:
 
     {{ reason }}


### PR DESCRIPTION
I opted to retain the use of "group" as the template variable
for the requested group name rather than the "requested" name
used in the pending_request template because I think group is
more readable. It might be a good idea to change the name of
the variable in pending_request to sync it with these
templates.