### PR TITLE
Fix a typo in the group request cancelled email template

### DIFF
--- a/grouper/fe/templates/email/request_cancelled_html.tmpl
+++ b/grouper/fe/templates/email/request_cancelled_html.tmpl
@@ -6,7 +6,7 @@
 
 <p>Your request to join the group
 <strong><a href="{{url}}/groups/{{requested}}">{{ group }}</a></strong>
-has been cancelled by {{ actioned_by }}.  The reason they gave was:</p>
+has been cancelled by {{ cancelled_by }}.  The reason they gave was:</p>
 
 <blockquote><p>{{ reason|escape }}</p></blockquote>
 


### PR DESCRIPTION
The email now properly includes who cancelled the group request