### PR TITLE
Add support for default expiration times for groups

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -42,7 +42,7 @@ class ValidateDate(object):
 class DaysTimeDeltaField(IntegerField):
 
     def process_data(self, value):
-        """Converting from TimeDelta notation to a simple integer"""
+        """Converts from TimeDelta notation to a simple integer"""
         # Do the check because groups with no expiration will result in value being None
         if hasattr(value, "days"):
             self.data = value.days

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import re
 
 import sshpubkey
@@ -37,6 +37,25 @@ class ValidateDate(object):
         except ValueError:
             raise ValidationError(
                 "{} does not match format 'MM/DD/YYYY'".format(field.data))
+
+
+class DaysTimeDeltaField(IntegerField):
+
+    def process_data(self, value):
+        """Converting from TimeDelta notation to a simple integer"""
+        # Do the check because groups with no expiration will result in value being None
+        if hasattr(value, "days"):
+            self.data = value.days
+        else:
+            self.data = None
+
+    def process_formdata(self, valuelist):
+        # We need to support None values for groups with no expiration
+        if valuelist and valuelist[0]:
+            super(DaysTimeDeltaField, self).process_formdata(valuelist)
+            self.data = timedelta(days=self.data)
+        else:
+            self.data = None
 
 
 class ValidatePublicKey(object):
@@ -89,6 +108,7 @@ class GroupCreateForm(Form):
         ("canjoin", "Anyone"), ("canask", "Must Ask"),
         ("nobody", "Nobody"),
     ], default="canask")
+    auto_expire = DaysTimeDeltaField("Default Expiration (Days)")
 
 
 class GroupEditForm(Form):
@@ -102,6 +122,7 @@ class GroupEditForm(Form):
         ("canjoin", "Anyone"), ("canask", "Must Ask"),
         ("nobody", "Nobody"),
     ], default="canask")
+    auto_expire = DaysTimeDeltaField("Default Expiration (Days)")
 
 
 class AuditCreateForm(Form):

--- a/grouper/fe/handlers/group_edit.py
+++ b/grouper/fe/handlers/group_edit.py
@@ -38,6 +38,7 @@ class GroupEdit(GrouperHandler):
         group.groupname = form.data["groupname"]
         group.description = form.data["description"]
         group.canjoin = form.data["canjoin"]
+        group.auto_expire = form.data["auto_expire"]
         Counter.incr(self.session, "updates")
 
         try:

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -68,9 +68,17 @@ class GroupJoin(GrouperHandler):
                 ]
             )
 
+        # We only use the default expiration time if no expiration time was given
+        # This does mean that if a user wishes to join a group with no expiration
+        # (even with an owner's permission) that has an auto expiration, they must
+        # first be accepted to the group and then have the owner edit the user to
+        # have no expiration.
+
         expiration = None
         if form.data["expiration"]:
             expiration = datetime.strptime(form.data["expiration"], "%m/%d/%Y")
+        elif group.auto_expire:
+            expiration = datetime.utcnow() + group.auto_expire
 
         group.add_member(
             requester=self.current_user,

--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -50,7 +50,8 @@ class GroupsView(GrouperHandler):
         group = Group(
             groupname=form.data["groupname"],
             description=form.data["description"],
-            canjoin=form.data["canjoin"]
+            canjoin=form.data["canjoin"],
+            auto_expire=form.data["auto_expire"],
         )
         try:
             group.add(self.session)

--- a/grouper/fe/templates/forms/group.html
+++ b/grouper/fe/templates/forms/group.html
@@ -17,5 +17,6 @@
 {{ form_field(form.groupname, 3, 8, class_="form-control") }}
 {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
 {{ form_field(form.canjoin, 3, 4, class_="form-control") }}
+{{ form_field(form.auto_expire, 3, 4, class_="form-control") }}
 
 {{ xsrf_form() }}

--- a/grouper/model_soup.py
+++ b/grouper/model_soup.py
@@ -13,7 +13,7 @@ import re
 from sqlalchemy import asc, desc, or_, union_all
 from sqlalchemy import (
     Boolean, Column, DateTime, Enum, ForeignKey, Index,
-    Integer, SmallInteger, String, Text
+    Integer, Interval, SmallInteger, String, Text
 )
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import aliased
@@ -454,6 +454,10 @@ class Group(Model, CommentObjectMixin):
     description = Column(Text)
     canjoin = Column(Enum(*GROUP_JOIN_CHOICES), default="canask")
     enabled = Column(Boolean, default=True, nullable=False)
+    # The default amount of time new users have before their membership in the group is expired
+    # NOTE: This only applies to users who join a group via a request in the front end. It does
+    # not apply to users who are added to a group by an approver
+    auto_expire = Column(Interval)
 
     audit_id = Column(Integer, nullable=True)
     audit = relationship("Audit", foreign_keys=[audit_id],


### PR DESCRIPTION
Adds the auto_expire attribute to Group. When a user requests to
join a group (only via the front end), if they do not provide an
expiration date, their expiration is automatically set to auto_expire
days in the future. This happens for both canask and canjoin requests,
but does not apply to when a user is added to a group via a non
front end mechanism, or when an approver directly adds a member to
the group.

Ensures that the value of Group.auto_expire is correctly used where
appropriate (when a user submits a request and doesn't provide an
expiration time) and is not used where inappropriate (a user submits
a request and does provide an expiration time, an approver adds the
user via the add member feature, or the approver edits a member in
the group and leaves the expiration blank)