### PR TITLE
Add support for public key tags

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -38,6 +38,7 @@ AUDIT_MANAGER = "grouper.audit.manage"
 AUDIT_VIEWER = "grouper.audit.view"
 USER_DISABLE = "grouper.user.disable"
 USER_ENABLE = "grouper.user.enable"
+TAG_EDIT = "grouper.tag.edit"
 
 # Permissions that are always created and are reserved.
 SYSTEM_PERMISSIONS = [
@@ -52,6 +53,7 @@ SYSTEM_PERMISSIONS = [
     (AUDIT_VIEWER, "Ability to view audit results and status."),
     (USER_ENABLE, "Ability to enable a disabled user."),
     (USER_DISABLE, "Ability to disable an enabled user."),
+    (TAG_EDIT, "Ability to edit the permissions granted to a tag."),
 ]
 
 # Used to construct name tuples in notification engine.

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -291,3 +291,32 @@ class UserShellForm(Form):
     shell = SelectField("Shell", [
         validators.DataRequired(),
     ])
+
+
+class TagCreateForm(Form):
+    tagname = StringField("Name", [
+        validators.Length(min=3, max=32),
+        validators.DataRequired(),
+        ValidateRegex(constants.NAME_VALIDATION),
+    ])
+    description = TextAreaField("Description")
+
+
+class TagEditForm(Form):
+    description = TextAreaField("Description")
+
+
+class PermissionGrantTagForm(Form):
+    permission = SelectField("Permission", [
+        validators.DataRequired(),
+    ], choices=[["", "(select one)"]], default="")
+    argument = StringField("Argument", [
+        validators.Length(min=0, max=constants.MAX_NAME_LENGTH),
+        ValidateRegex(constants.ARGUMENT_VALIDATION),
+    ])
+
+
+class PublicKeyAddTagForm(Form):
+    tagname = SelectField("Tag", [
+        validators.DataRequired(),
+    ], choices=[["", "(select one)"]], default="")

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -304,6 +304,7 @@ class TagCreateForm(Form):
 
 class TagEditForm(Form):
     description = TextAreaField("Description")
+    enabled = BooleanField("Enabled")
 
 
 class PermissionGrantTagForm(Form):

--- a/grouper/fe/handlers/help.py
+++ b/grouper/fe/handlers/help.py
@@ -1,4 +1,4 @@
-from grouper.constants import PERMISSION_AUDITOR, PERMISSION_CREATE, PERMISSION_GRANT
+from grouper.constants import PERMISSION_AUDITOR, PERMISSION_CREATE, PERMISSION_GRANT, TAG_EDIT
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.models.permission import Permission
@@ -17,4 +17,5 @@ class Help(GrouperHandler):
                     site_docs=settings.site_docs,
                     grant_perm=d[PERMISSION_GRANT],
                     create_perm=d[PERMISSION_CREATE],
-                    audit_perm=d[PERMISSION_AUDITOR])
+                    audit_perm=d[PERMISSION_AUDITOR],
+                    tag_edit=d[TAG_EDIT])

--- a/grouper/fe/handlers/permissions_grant_tag.py
+++ b/grouper/fe/handlers/permissions_grant_tag.py
@@ -5,6 +5,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.permission import Permission
 from grouper.models.public_key_tag import PublicKeyTag
 from grouper.permissions import grant_permission_to_tag
+from grouper.user_permissions import user_has_permission
 
 
 class PermissionsGrantTag(GrouperHandler):
@@ -13,7 +14,7 @@ class PermissionsGrantTag(GrouperHandler):
         if not tag:
             return self.notfound()
 
-        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+        if not user_has_permission(self.session, self.current_user, TAG_EDIT, tag.name):
             return self.forbidden()
 
         form = PermissionGrantTagForm()
@@ -31,7 +32,7 @@ class PermissionsGrantTag(GrouperHandler):
         if not tag:
             return self.notfound()
 
-        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+        if not user_has_permission(self.session, self.current_user, TAG_EDIT, tag.name):
             return self.forbidden()
 
         form = PermissionGrantTagForm(self.request.arguments)

--- a/grouper/fe/handlers/permissions_grant_tag.py
+++ b/grouper/fe/handlers/permissions_grant_tag.py
@@ -1,0 +1,73 @@
+from sqlalchemy.exc import IntegrityError
+from grouper.fe.forms import PermissionGrantTagForm
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.permissions import grant_permission_to_tag
+from grouper.models.permission import Permission
+from grouper.constants import TAG_EDIT
+from grouper.models.public_key_tag import PublicKeyTag
+
+
+class PermissionsGrantTag(GrouperHandler):
+    def get(self, name=None):
+        tag = PublicKeyTag.get(self.session, None, name)
+        if not tag:
+            return self.notfound()
+
+        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+            return self.forbidden()
+
+        form = PermissionGrantTagForm()
+        form.permission.choices = [["", "(select one)"]]
+
+        for perm in self.session.query(Permission).all():
+            form.permission.choices.append([perm.name, "{} (*)".format(perm.name)])
+
+        return self.render(
+            "permission-grant-tag.html", form=form, tag=tag,
+        )
+
+    def post(self, name=None):
+        tag = PublicKeyTag.get(self.session, None, name)
+        if not tag:
+            return self.notfound()
+
+        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+            return self.forbidden()
+
+        form = PermissionGrantTagForm(self.request.arguments)
+        form.permission.choices = [["", "(select one)"]]
+
+        for perm in self.session.query(Permission).all():
+            form.permission.choices.append([perm.name, "{} (*)".format(perm.name)])
+
+        if not form.validate():
+            return self.render(
+                "permission-grant-tag.html", form=form, tag=tag,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        permission = Permission.get(self.session, form.data["permission"])
+        if not permission:
+            return self.notfound()  # Shouldn't happen.
+
+        try:
+            grant_permission_to_tag(self.session, tag.id, permission.id,
+                                    argument=form.data["argument"])
+        except IntegrityError:
+            form.argument.errors.append(
+                "Permission and Argument already mapped to this tag."
+            )
+            self.session.rollback()
+            return self.render(
+                "permission-grant-tag.html", form=form, tag=tag,
+                alerts=self.get_form_alerts(form.errors),
+            )
+
+        self.session.commit()
+
+        AuditLog.log(self.session, self.current_user.id, 'grant_permission_tag',
+                     'Granted permission with argument: {}'.format(form.data["argument"]),
+                     on_permission_id=permission.id, on_tag_id=tag.id)
+
+        return self.redirect("/tags/{}?refresh=yes".format(tag.name))

--- a/grouper/fe/handlers/permissions_revoke_tag.py
+++ b/grouper/fe/handlers/permissions_revoke_tag.py
@@ -1,0 +1,39 @@
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.models.counter import Counter
+from grouper.models.tag_permission_map import TagPermissionMap
+from grouper.constants import TAG_EDIT
+
+
+class PermissionsRevokeTag(GrouperHandler):
+    def get(self, name=None, mapping_id=None):
+
+        mapping = TagPermissionMap.get(self.session, id=mapping_id)
+        if not mapping:
+            return self.notfound()
+
+        if not self.current_user.has_permission(TAG_EDIT, mapping.tag.name):
+            return self.forbidden()
+
+        self.render("permission-revoke-tag.html", mapping=mapping)
+
+    def post(self, name=None, mapping_id=None):
+        mapping = TagPermissionMap.get(self.session, id=mapping_id)
+        if not mapping:
+            return self.notfound()
+
+        if not self.current_user.has_permission(TAG_EDIT, mapping.tag.name):
+            return self.forbidden()
+
+        permission = mapping.permission
+        tag = mapping.tag
+
+        mapping.delete(self.session)
+        Counter.incr(self.session, "updates")
+        self.session.commit()
+
+        AuditLog.log(self.session, self.current_user.id, 'revoke_tag_permission',
+                     'Revoked permission with argument: {}'.format(mapping.argument),
+                     on_tag_id=tag.id, on_permission_id=permission.id)
+
+        return self.redirect('/tags/{}?refresh=yes'.format(tag.name))

--- a/grouper/fe/handlers/permissions_revoke_tag.py
+++ b/grouper/fe/handlers/permissions_revoke_tag.py
@@ -1,8 +1,8 @@
+from grouper.constants import TAG_EDIT
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.counter import Counter
 from grouper.models.tag_permission_map import TagPermissionMap
-from grouper.constants import TAG_EDIT
 
 
 class PermissionsRevokeTag(GrouperHandler):

--- a/grouper/fe/handlers/permissions_revoke_tag.py
+++ b/grouper/fe/handlers/permissions_revoke_tag.py
@@ -3,6 +3,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.counter import Counter
 from grouper.models.tag_permission_map import TagPermissionMap
+from grouper.user_permissions import user_has_permission
 
 
 class PermissionsRevokeTag(GrouperHandler):
@@ -12,7 +13,7 @@ class PermissionsRevokeTag(GrouperHandler):
         if not mapping:
             return self.notfound()
 
-        if not self.current_user.has_permission(TAG_EDIT, mapping.tag.name):
+        if not user_has_permission(self.session, self.current_user, TAG_EDIT, mapping.tag.name):
             return self.forbidden()
 
         self.render("permission-revoke-tag.html", mapping=mapping)
@@ -22,7 +23,7 @@ class PermissionsRevokeTag(GrouperHandler):
         if not mapping:
             return self.notfound()
 
-        if not self.current_user.has_permission(TAG_EDIT, mapping.tag.name):
+        if not user_has_permission(self.session, self.current_user, TAG_EDIT, mapping.tag.name):
             return self.forbidden()
 
         permission = mapping.permission

--- a/grouper/fe/handlers/public_key_add_tag.py
+++ b/grouper/fe/handlers/public_key_add_tag.py
@@ -1,0 +1,73 @@
+from grouper.fe.util import GrouperHandler
+from grouper.model_soup import User
+from grouper.models.audit_log import AuditLog
+from grouper.public_key import get_public_key, KeyNotFound, add_tag_to_public_key, DuplicateTag
+from grouper.fe.forms import PublicKeyAddTagForm
+from grouper.models.public_key_tag import PublicKeyTag
+
+
+class PublicKeyAddTag(GrouperHandler):
+    def get(self, user_id=None, name=None, key_id=None):
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if (user.name != self.current_user.name) and not self.current_user.user_admin:
+            return self.forbidden()
+
+        try:
+            key = get_public_key(self.session, user.id, key_id)
+        except KeyNotFound:
+            return self.notfound()
+
+        form = PublicKeyAddTagForm()
+        for tag in self.session.query(PublicKeyTag).all():
+            form.tagname.choices.append([tag.name, tag.name])
+
+        self.render("public-key-add-tag.html", user=user, key=key, form=form)
+
+    def post(self, user_id=None, name=None, key_id=None):
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if (user.name != self.current_user.name) and not self.current_user.user_admin:
+            return self.forbidden()
+
+        try:
+            key = get_public_key(self.session, user.id, key_id)
+        except KeyNotFound:
+            return self.notfound()
+
+        form = PublicKeyAddTagForm(self.request.arguments)
+        for tag in self.session.query(PublicKeyTag).all():
+            form.tagname.choices.append([tag.name, tag.name])
+
+        if not form.validate():
+            return self.render(
+                "public-key-add-tag.html", form=form, user=user, key=key,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        tag = PublicKeyTag.get(self.session, name=form.data["tagname"])
+
+        if not tag:
+            form.tagname.errors.append("Unknown tag name {}".format(form.data["tagname"]))
+            return self.render(
+                "public-key-add-tag.html", form=form, user=user, key=key,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        try:
+            add_tag_to_public_key(self.session, key, tag)
+        except DuplicateTag:
+            return self.render(
+                "public-key-add-tag.html", form=form, user=user, key=key,
+                alerts=["This key already has that tag!"]
+            )
+
+        AuditLog.log(self.session, self.current_user.id, 'tag_public_key',
+                     'Tagged public key: {}'.format(key.fingerprint),
+                     on_tag_id=tag.id, on_user_id=user.id)
+
+        return self.redirect("/users/{}?refresh=yes".format(user.name))

--- a/grouper/fe/handlers/public_key_add_tag.py
+++ b/grouper/fe/handlers/public_key_add_tag.py
@@ -1,9 +1,9 @@
+from grouper.fe.forms import PublicKeyAddTagForm
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import User
 from grouper.models.audit_log import AuditLog
-from grouper.public_key import get_public_key, KeyNotFound, add_tag_to_public_key, DuplicateTag
-from grouper.fe.forms import PublicKeyAddTagForm
 from grouper.models.public_key_tag import PublicKeyTag
+from grouper.public_key import add_tag_to_public_key, DuplicateTag, get_public_key, KeyNotFound
 
 
 class PublicKeyAddTag(GrouperHandler):

--- a/grouper/fe/handlers/public_key_add_tag.py
+++ b/grouper/fe/handlers/public_key_add_tag.py
@@ -21,7 +21,8 @@ class PublicKeyAddTag(GrouperHandler):
             return self.notfound()
 
         form = PublicKeyAddTagForm()
-        for tag in self.session.query(PublicKeyTag).all():
+        form.tagname.choices = []
+        for tag in self.session.query(PublicKeyTag).filter_by(enabled=True).all():
             form.tagname.choices.append([tag.name, tag.name])
 
         self.render("public-key-add-tag.html", user=user, key=key, form=form)
@@ -40,7 +41,8 @@ class PublicKeyAddTag(GrouperHandler):
             return self.notfound()
 
         form = PublicKeyAddTagForm(self.request.arguments)
-        for tag in self.session.query(PublicKeyTag).all():
+        form.tagname.choices = []
+        for tag in self.session.query(PublicKeyTag).filter_by(enabled=True).all():
             form.tagname.choices.append([tag.name, tag.name])
 
         if not form.validate():

--- a/grouper/fe/handlers/public_key_remove_tag.py
+++ b/grouper/fe/handlers/public_key_remove_tag.py
@@ -1,8 +1,8 @@
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import User
 from grouper.models.audit_log import AuditLog
-from grouper.public_key import get_public_key, KeyNotFound, remove_tag_from_public_key, TagNotOnKey
 from grouper.models.public_key_tag import PublicKeyTag
+from grouper.public_key import get_public_key, KeyNotFound, remove_tag_from_public_key, TagNotOnKey
 
 
 class PublicKeyRemoveTag(GrouperHandler):

--- a/grouper/fe/handlers/public_key_remove_tag.py
+++ b/grouper/fe/handlers/public_key_remove_tag.py
@@ -1,0 +1,36 @@
+from grouper.fe.util import GrouperHandler
+from grouper.model_soup import User
+from grouper.models.audit_log import AuditLog
+from grouper.public_key import get_public_key, KeyNotFound, remove_tag_from_public_key, TagNotOnKey
+from grouper.models.public_key_tag import PublicKeyTag
+
+
+class PublicKeyRemoveTag(GrouperHandler):
+    def post(self, user_id=None, name=None, key_id=None, tag_id=None):
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if (user.name != self.current_user.name) and not self.current_user.user_admin:
+            return self.forbidden()
+
+        try:
+            key = get_public_key(self.session, user.id, key_id)
+        except KeyNotFound:
+            return self.notfound()
+
+        tag = PublicKeyTag.get(self.session, id=tag_id)
+
+        if not tag:
+            return self.notfound()
+
+        try:
+            remove_tag_from_public_key(self.session, key, tag)
+        except TagNotOnKey:
+            return self.redirect("/users/{}?refresh=yes".format(user.name))
+
+        AuditLog.log(self.session, self.current_user.id, 'untag_public_key',
+                     'Untagged public key: {}'.format(key.fingerprint),
+                     on_tag_id=tag.id, on_user_id=user.id)
+
+        return self.redirect("/users/{}?refresh=yes".format(user.name))

--- a/grouper/fe/handlers/tag_edit.py
+++ b/grouper/fe/handlers/tag_edit.py
@@ -36,6 +36,7 @@ class TagEdit(GrouperHandler):
             )
 
         tag.description = form.data["description"]
+        tag.enabled = form.data["enabled"]
         Counter.incr(self.session, "updates")
 
         try:

--- a/grouper/fe/handlers/tag_edit.py
+++ b/grouper/fe/handlers/tag_edit.py
@@ -6,6 +6,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.counter import Counter
 from grouper.models.public_key_tag import PublicKeyTag
+from grouper.user_permissions import user_has_permission
 
 
 class TagEdit(GrouperHandler):
@@ -14,7 +15,7 @@ class TagEdit(GrouperHandler):
         if not tag:
             return self.notfound()
 
-        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+        if not user_has_permission(self.session, self.current_user, TAG_EDIT, tag.name):
             return self.forbidden()
 
         form = TagEditForm(obj=tag)
@@ -26,7 +27,7 @@ class TagEdit(GrouperHandler):
         if not tag:
             return self.notfound()
 
-        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+        if not user_has_permission(self.session, self.current_user, TAG_EDIT, tag.name):
             return self.forbidden()
 
         form = TagEditForm(self.request.arguments, obj=tag)

--- a/grouper/fe/handlers/tag_edit.py
+++ b/grouper/fe/handlers/tag_edit.py
@@ -1,10 +1,11 @@
 from sqlalchemy.exc import IntegrityError
+
+from grouper.constants import TAG_EDIT
 from grouper.fe.forms import TagEditForm
 from grouper.fe.util import GrouperHandler
-from grouper.models.counter import Counter
 from grouper.models.audit_log import AuditLog
+from grouper.models.counter import Counter
 from grouper.models.public_key_tag import PublicKeyTag
-from grouper.constants import TAG_EDIT
 
 
 class TagEdit(GrouperHandler):

--- a/grouper/fe/handlers/tag_edit.py
+++ b/grouper/fe/handlers/tag_edit.py
@@ -1,0 +1,56 @@
+from sqlalchemy.exc import IntegrityError
+from grouper.fe.forms import TagEditForm
+from grouper.fe.util import GrouperHandler
+from grouper.models.counter import Counter
+from grouper.models.audit_log import AuditLog
+from grouper.models.public_key_tag import PublicKeyTag
+from grouper.constants import TAG_EDIT
+
+
+class TagEdit(GrouperHandler):
+    def get(self, tag_id=None, name=None):
+        tag = PublicKeyTag.get(self.session, tag_id, name)
+        if not tag:
+            return self.notfound()
+
+        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+            return self.forbidden()
+
+        form = TagEditForm(obj=tag)
+
+        self.render("tag-edit.html", tag=tag, form=form)
+
+    def post(self, tag_id=None, name=None):
+        tag = PublicKeyTag.get(self.session, tag_id, name)
+        if not tag:
+            return self.notfound()
+
+        if not self.current_user.has_permission(TAG_EDIT, tag.name):
+            return self.forbidden()
+
+        form = TagEditForm(self.request.arguments, obj=tag)
+        if not form.validate():
+            return self.render(
+                "tag-edit.html", tag=tag, form=form,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        tag.description = form.data["description"]
+        Counter.incr(self.session, "updates")
+
+        try:
+            self.session.commit()
+        except IntegrityError:
+            self.session.rollback()
+            form.tagname.errors.append(
+                "{} already exists".format(form.data["tagname"])
+            )
+            return self.render(
+                "tag-edit.html", tag=tag, form=form,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        AuditLog.log(self.session, self.current_user.id, 'edit_tag',
+                     'Edited tag.', on_tag_id=tag.id)
+
+        return self.redirect("/tags/{}".format(tag.name))

--- a/grouper/fe/handlers/tag_view.py
+++ b/grouper/fe/handlers/tag_view.py
@@ -1,0 +1,22 @@
+from grouper.fe.util import GrouperHandler
+from grouper.model_soup import Permission
+from grouper.models.public_key_tag import PublicKeyTag
+from grouper.constants import TAG_EDIT
+
+
+class TagView(GrouperHandler):
+    def get(self, tag_id=None, name=None):
+        self.handle_refresh()
+        tag = PublicKeyTag.get(self.session, tag_id, name)
+        if not tag:
+            return self.notfound()
+
+        permissions = tag.my_permissions()
+        log_entries = tag.my_log_entries()
+        is_owner = self.current_user.has_permission(TAG_EDIT, tag.name)
+        can_grant = self.session.query(Permission).all() if is_owner else []
+
+        self.render(
+            "tag.html", tag=tag, permissions=permissions, can_grant=can_grant,
+            log_entries=log_entries, is_owner=is_owner,
+        )

--- a/grouper/fe/handlers/tag_view.py
+++ b/grouper/fe/handlers/tag_view.py
@@ -2,6 +2,7 @@ from grouper.constants import TAG_EDIT
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Permission
 from grouper.models.public_key_tag import PublicKeyTag
+from grouper.public_key import get_public_key_tag_permissions
 
 
 class TagView(GrouperHandler):
@@ -11,7 +12,7 @@ class TagView(GrouperHandler):
         if not tag:
             return self.notfound()
 
-        permissions = tag.my_permissions()
+        permissions = get_public_key_tag_permissions(self.session, tag)
         log_entries = tag.my_log_entries()
         is_owner = self.current_user.has_permission(TAG_EDIT, tag.name)
         can_grant = self.session.query(Permission).all() if is_owner else []

--- a/grouper/fe/handlers/tag_view.py
+++ b/grouper/fe/handlers/tag_view.py
@@ -1,7 +1,7 @@
+from grouper.constants import TAG_EDIT
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Permission
 from grouper.models.public_key_tag import PublicKeyTag
-from grouper.constants import TAG_EDIT
 
 
 class TagView(GrouperHandler):

--- a/grouper/fe/handlers/tag_view.py
+++ b/grouper/fe/handlers/tag_view.py
@@ -3,6 +3,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Permission
 from grouper.models.public_key_tag import PublicKeyTag
 from grouper.public_key import get_public_key_tag_permissions
+from grouper.user_permissions import user_has_permission
 
 
 class TagView(GrouperHandler):
@@ -14,7 +15,7 @@ class TagView(GrouperHandler):
 
         permissions = get_public_key_tag_permissions(self.session, tag)
         log_entries = tag.my_log_entries()
-        is_owner = self.current_user.has_permission(TAG_EDIT, tag.name)
+        is_owner = user_has_permission(self.session, self.current_user, TAG_EDIT, tag.name)
         can_grant = self.session.query(Permission).all() if is_owner else []
 
         self.render(

--- a/grouper/fe/handlers/tags_view.py
+++ b/grouper/fe/handlers/tags_view.py
@@ -1,7 +1,9 @@
 from sqlalchemy.exc import IntegrityError
+
 from grouper.fe.forms import TagCreateForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
+from grouper.models.counter import Counter
 from grouper.models.public_key_tag import PublicKeyTag
 
 
@@ -50,6 +52,7 @@ class TagsView(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors)
             )
 
+        Counter.incr(self.session, "updates")
         self.session.commit()
 
         AuditLog.log(self.session, self.current_user.id, 'create_tag',

--- a/grouper/fe/handlers/tags_view.py
+++ b/grouper/fe/handlers/tags_view.py
@@ -1,0 +1,58 @@
+from sqlalchemy.exc import IntegrityError
+from grouper.fe.forms import TagCreateForm
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.models.public_key_tag import PublicKeyTag
+
+
+class TagsView(GrouperHandler):
+    def get(self):
+        self.handle_refresh()
+        offset = int(self.get_argument("offset", 0))
+        limit = int(self.get_argument("limit", 100))
+        if limit > 9000:
+            limit = 9000
+
+        tags = self.session.query(PublicKeyTag).all()
+        total = len(tags)
+        tags = tags[offset:offset + limit]
+
+        form = TagCreateForm()
+
+        self.render(
+            "tags.html", tags=tags, form=form,
+            offset=offset, limit=limit, total=total,
+        )
+
+    def post(self):
+        form = TagCreateForm(self.request.arguments)
+        if not form.validate():
+            return self.render(
+                "tag-create.html", form=form,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        tag = PublicKeyTag(
+            name=form.data["tagname"],
+            description=form.data["description"],
+        )
+
+        try:
+            tag.add(self.session)
+            self.session.flush()
+        except IntegrityError:
+            self.session.rollback()
+            form.tagname.errors.append(
+                "{} already exists".format(form.data["tagname"])
+            )
+            return self.render(
+                "tag-create.html", form=form,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        self.session.commit()
+
+        AuditLog.log(self.session, self.current_user.id, 'create_tag',
+                     'Created new tag.', on_tag_id=tag.id)
+
+        return self.redirect("/tags/{}?refresh=yes".format(tag.name))

--- a/grouper/fe/handlers/user_view.py
+++ b/grouper/fe/handlers/user_view.py
@@ -6,7 +6,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.graph import NoSuchUser
 from grouper.models.user import User
 from grouper.permissions import get_requests_by_owner
-from grouper.public_key import get_public_keys_of_user
+from grouper.public_key import get_public_key_permissions, get_public_keys_of_user
 from grouper.user import get_log_entries_by_user, user_open_audits, user_requests_aggregate
 from grouper.user_metadata import get_user_metadata_by_key
 from grouper.user_permissions import user_is_user_admin
@@ -52,6 +52,11 @@ class UserView(GrouperHandler):
         group_edge_list = group_biz.get_groups_by_user(self.session, user) if user.enabled else []
         groups = [{'name': g.name, 'type': 'Group', 'role': ge._role} for g, ge in group_edge_list]
         public_keys = get_public_keys_of_user(self.session, user.id)
+        for key in public_keys:
+            key.tags = get_public_key_tags(self.session, key)
+            key.pretty_permissions = ["{} ({})".format(perm.name,
+               perm.argument if perm.argument else "unargumented")
+               for perm in get_public_key_permissions(self.session, key)]
         permissions = user_md.get('permissions', [])
         log_entries = get_log_entries_by_user(self.session, user)
         self.render("user.html",

--- a/grouper/fe/handlers/user_view.py
+++ b/grouper/fe/handlers/user_view.py
@@ -6,7 +6,8 @@ from grouper.fe.util import GrouperHandler
 from grouper.graph import NoSuchUser
 from grouper.models.user import User
 from grouper.permissions import get_requests_by_owner
-from grouper.public_key import get_public_key_permissions, get_public_keys_of_user
+from grouper.public_key import (get_public_key_permissions, get_public_key_tags,
+    get_public_keys_of_user)
 from grouper.user import get_log_entries_by_user, user_open_audits, user_requests_aggregate
 from grouper.user_metadata import get_user_metadata_by_key
 from grouper.user_permissions import user_is_user_admin

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -36,8 +36,8 @@ from grouper.fe.handlers.permissions_revoke import PermissionsRevoke
 from grouper.fe.handlers.permissions_revoke_tag import PermissionsRevokeTag
 from grouper.fe.handlers.permissions_view import PermissionsView
 from grouper.fe.handlers.public_key_add import PublicKeyAdd
-from grouper.fe.handlers.public_key_delete import PublicKeyDelete
 from grouper.fe.handlers.public_key_add_tag import PublicKeyAddTag
+from grouper.fe.handlers.public_key_delete import PublicKeyDelete
 from grouper.fe.handlers.public_key_remove_tag import PublicKeyRemoveTag
 from grouper.fe.handlers.search import Search
 from grouper.fe.handlers.stats import Stats

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -29,14 +29,21 @@ from grouper.fe.handlers.permission_enable_auditing import PermissionEnableAudit
 from grouper.fe.handlers.permission_view import PermissionView
 from grouper.fe.handlers.permissions_create import PermissionsCreate
 from grouper.fe.handlers.permissions_grant import PermissionsGrant
+from grouper.fe.handlers.permissions_grant_tag import PermissionsGrantTag
 from grouper.fe.handlers.permissions_request_update import PermissionsRequestUpdate
 from grouper.fe.handlers.permissions_requests import PermissionsRequests
 from grouper.fe.handlers.permissions_revoke import PermissionsRevoke
+from grouper.fe.handlers.permissions_revoke_tag import PermissionsRevokeTag
 from grouper.fe.handlers.permissions_view import PermissionsView
 from grouper.fe.handlers.public_key_add import PublicKeyAdd
 from grouper.fe.handlers.public_key_delete import PublicKeyDelete
+from grouper.fe.handlers.public_key_add_tag import PublicKeyAddTag
+from grouper.fe.handlers.public_key_remove_tag import PublicKeyRemoveTag
 from grouper.fe.handlers.search import Search
 from grouper.fe.handlers.stats import Stats
+from grouper.fe.handlers.tags_view import TagsView
+from grouper.fe.handlers.tag_view import TagView
+from grouper.fe.handlers.tag_edit import TagEdit
 from grouper.fe.handlers.user_disable import UserDisable
 from grouper.fe.handlers.user_enable import UserEnable
 from grouper.fe.handlers.user_requests import UserRequests
@@ -55,6 +62,7 @@ HANDLERS = [
     (r"/audits/(?P<audit_id>[0-9]+)/complete", AuditsComplete),
     (r"/audits/create", AuditsCreate),
     (r"/groups", GroupsView),
+    (r"/tags", TagsView),
     (r"/permissions/create", PermissionsCreate),
     (r"/permissions/requests", PermissionsRequests),
     (r"/permissions/requests/(?P<request_id>[0-9]+)", PermissionsRequestUpdate),
@@ -85,6 +93,14 @@ for regex in (r"(?P<user_id>[0-9]+)", USERNAME_VALIDATION):
             r"/users/{}/public-key/(?P<key_id>[0-9]+)/delete".format(regex),
             PublicKeyDelete
         ),
+        (
+            r"/users/{}/public-key/(?P<key_id>[0-9]+)/tag".format(regex),
+            PublicKeyAddTag
+        ),
+        (
+            r"/users/{}/public-key/(?P<key_id>[0-9]+)/delete_tag/(?P<tag_id>[0-9]+)".format(regex),
+            PublicKeyRemoveTag
+        ),
         (r"/users/{}/tokens/add".format(regex), UserTokenAdd),
         (r"/users/{}/tokens/(?P<token_id>[0-9]+)/disable".format(regex), UserTokenDisable),
     ])
@@ -106,6 +122,18 @@ for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):
             r"/groups/{}/edit/(?P<member_type>user|group)/{}".format(regex, NAME2_VALIDATION),
             GroupEditMember
         ),
+    ])
+
+for regex in (r"(?P<tag_id>[0-9]+)", NAME_VALIDATION):
+    HANDLERS.extend([
+        (r"/tags/{}".format(regex), TagView),
+        (r"/tags/{}/edit".format(regex), TagEdit),
+        (r"/permissions/grant_tag/{}".format(regex), PermissionsGrantTag),
+        (
+            r"/permissions/{}/revoke_tag/(?P<mapping_id>[0-9]+)".format(PERMISSION_VALIDATION),
+            PermissionsRevokeTag
+        ),
+
     ])
 
 HANDLERS += [

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -41,9 +41,9 @@ from grouper.fe.handlers.public_key_add_tag import PublicKeyAddTag
 from grouper.fe.handlers.public_key_remove_tag import PublicKeyRemoveTag
 from grouper.fe.handlers.search import Search
 from grouper.fe.handlers.stats import Stats
-from grouper.fe.handlers.tags_view import TagsView
-from grouper.fe.handlers.tag_view import TagView
 from grouper.fe.handlers.tag_edit import TagEdit
+from grouper.fe.handlers.tag_view import TagView
+from grouper.fe.handlers.tags_view import TagsView
 from grouper.fe.handlers.user_disable import UserDisable
 from grouper.fe.handlers.user_enable import UserEnable
 from grouper.fe.handlers.user_requests import UserRequests

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -35,6 +35,7 @@
                 <div class="navbar-collapse collapse">
                     <ul class="nav navbar-nav">
                         <li class="{{is_active('/groups')}}"><a href="/groups">Groups</a></li>
+                        <li class="{{is_active('/tags')}}"><a href="/tags">Tags</a></li>
                         <li class="{{is_active('/users')}}"><a href="/users">Users</a></li>
                         <li class="{{is_active('/permissions')}}"><a href="/permissions">Permissions</a></li>
                         <li class="{{is_active('/help')}}"><a href="/help">Help</a></li>

--- a/grouper/fe/templates/forms/public-key-add-tag.html
+++ b/grouper/fe/templates/forms/public-key-add-tag.html
@@ -1,0 +1,15 @@
+{% macro form_field(field, label_width, field_width) -%}
+    <div class="form-group {% if field.errors %}has-error{% endif %}">
+        <label for="{{field.label.field_id}}"
+               class="col-sm-{{label_width}} control-label">
+            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+        </label>
+        <div class="col-sm-{{field_width}}">
+            {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}
+
+{{ form_field(form.tagname, 3, 8, class_="form-control") }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/forms/tag-edit.html
+++ b/grouper/fe/templates/forms/tag-edit.html
@@ -12,5 +12,6 @@
 
 
 {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
+{{ form_field(form.enabled, 3, 4, class_="form-control") }}
 
 {{ xsrf_form() }}

--- a/grouper/fe/templates/forms/tag-edit.html
+++ b/grouper/fe/templates/forms/tag-edit.html
@@ -1,0 +1,16 @@
+{% macro form_field(field, label_width, field_width) -%}
+    <div class="form-group {% if field.errors %}has-error{% endif %}">
+        <label for="{{field.label.field_id}}"
+               class="col-sm-{{label_width}} control-label">
+            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+        </label>
+        <div class="col-sm-{{field_width}}">
+            {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}
+
+
+{{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/forms/tag.html
+++ b/grouper/fe/templates/forms/tag.html
@@ -1,0 +1,17 @@
+{% macro form_field(field, label_width, field_width) -%}
+    <div class="form-group {% if field.errors %}has-error{% endif %}">
+        <label for="{{field.label.field_id}}"
+               class="col-sm-{{label_width}} control-label">
+            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+        </label>
+        <div class="col-sm-{{field_width}}">
+            {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}
+
+
+{{ form_field(form.tagname, 3, 8, class_="form-control") }}
+{{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/help.html
+++ b/grouper/fe/templates/help.html
@@ -75,6 +75,17 @@ owner, or np-owner of an audited group.</p>
 <p>We're working on tooling to facilitate regular monitoring of both members of audited
   groups and groups with audited permissions.</p>
 
+<h3>What are tags?</h3>
+<p>Tags are sets of permissions (similar to groups) that can be applied to public keys.
+Tags restrict the permissions of the public key that they are applied to. This allows
+users to have separate public keys for different permissions (and therefore services).
+In order to grant permissions to a tag, a user must have the {{permission(tag_edit)}}
+permission with the argument set to the tag's name. For most users, the only thing
+they need to do to use tags properly is to add the appropriate tag to the relevant
+public keys. If you have multiple tags on a single public key, the permissions of that
+public key are the intersection of the user's permissions and the permissions granted
+on the tags.</p>
+
 <h3>What if my questions aren't answered here?</h3>
 <p>This list isn't comprehensive. Please contact the admins of this site ({{
   how_to_get_help }}) for help and

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -1,25 +1,3 @@
-{% macro one_public_key_row(key, username, can_control) -%}
-    <td><span class="has-help" data-toggle="popover" data-content="{{ key.created_on|print_date }}">
-        {{ key.created_on|long_ago_str }}</span></td>
-    <td>{% if key.key_type %}{{ key.key_type }}{% endif %}</td>
-    <td>{% if key.key_size %}{{ key.key_size }}{% endif %}</td>
-    <td class="hidden-xs">
-        <code>{{ key.fingerprint }}</code>
-    </td>
-    <td>
-        <span class="pull-right">
-        <button class="btn btn-default btn-xs public-key" key-body="{{ key.public_key|escape }}">
-            <i class="fa fa-search"></i>
-        </button>
-    {% if can_control %}
-        <a class="btn btn-default btn-xs" href="/users/{{ username }}/public-key/{{ key.id }}/delete">
-            <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span>
-        </a>
-        </span>
-    {% endif %}
-    </td>
-{%- endmacro %}
-
 {% macro public_key_modal() -%}
     <div id="key-modal" class="modal fade">
         <div class="modal-dialog">
@@ -35,47 +13,6 @@
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
             </div>
-        </div>
-    </div>
-{%- endmacro %}
-
-{% macro public_key_panel(max_height, user, public_keys, can_control=False) -%}
-    {{ public_key_modal() }}
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">Public Keys</h3>
-        </div>
-        <div class="table-responsive" style="max-height: {{max_height}}px; overflow-y: auto">
-            <table class="table table-striped table-condensed">
-                <thead>
-                    <tr>
-                        <th class="col-sm-1">Age</th>
-                        <th class="col-sm-1">Type</th>
-                        <th class="col-sm-1">Size</th>
-                        <th class="col-sm-3 hidden-xs">Fingerprint</th>
-                        <th class="col-sm-2"></th>
-                    </tr>
-                </thead>
-                <tbody>
-                {% for key in public_keys %}
-                    <tr>
-                        {{ one_public_key_row(key, user.name, can_control) }}
-                    </tr>
-                {% endfor %}
-                {% if not public_keys %}
-                    <tr>
-                        <td colspan="5" class="text-center"><em>No Public Keys</em></td>
-                    </tr>
-                {% endif %}
-                </tbody>
-            </table>
-            {% if can_control %}
-            <div class='panel-footer'>
-                <a class="btn btn-default btn-sm" href="/users/{{ user.name }}/public-key/add">
-                <span class="glyphicon glyphicon-plus"></span> Add Public Key
-                </a>
-            </div>
-            {% endif %}
         </div>
     </div>
 {%- endmacro %}
@@ -238,6 +175,13 @@ enabled. Membership in this group is regularly reviewed.
 </a>
 {%- endmacro %}
 
+{% macro format_tag(t) -%}
+<a class="tag-link" href="/tags/{{t.name}}">
+    <i class="fa fa-tag hidden-xs"></i>
+    {{t.name}}
+</a>
+{%- endmacro %}
+
 {% macro member_row(group, member, members, current_user, current_user_role) -%}
     <tr>
         <td>
@@ -329,6 +273,9 @@ enabled. Membership in this group is regularly reviewed.
                         <td class="col-sm-2">{{ entry.action }}</td>
                         <td class="col-sm-2">{{ entry.description|escape }}</td>
                         <td class="col-sm-2">
+                            {% if entry.on_tag %}
+                                Tag: {{ format_tag(entry.on_tag) }}<br />
+                            {% endif %}
                             {% if entry.on_group %}
                                 Group: {{ account(entry.on_group) }}<br />
                             {% endif %}
@@ -497,3 +444,63 @@ enabled. Membership in this group is regularly reviewed.
         {% endif %}
     </div>
 {%- endmacro %}
+
+
+{% macro tag_permission_panel(max_height, mappings, tag, can_grant=None) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Permissions</h3>
+        </div>
+        <div style="max-height: {{max_height}}px; overflow-y: auto">
+            <table class="{% if mappings %}datatable {% endif %}table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Permission</th>
+                        <th class="col-sm-2">Argument</th>
+                        <th class="col-sm-2">Granted</th>
+                        {% if can_grant %}
+                            <th class="col-sm-2"></th>
+                        {% endif %}
+                    </tr>
+                </thead>
+                <tbody>
+                {% for map in mappings %}
+                    <tr>
+                        <td>{{ permission(map) }}</td>
+                        <td class="col-sm-2">{{ map.argument|default("(unargumented)", True)|escape }}</td>
+                        <td class="col-sm-2" title="{{ map.granted_on|print_date }}">
+                            {{ map.granted_on|long_ago_str }}
+                        </td>
+                        {% if can_grant %}
+                            <td class="col-sm-2">
+                            {% for grantable in can_grant if grantable.name == map.name %}
+                                {% if loop.first %}
+                                    <a class="btn btn-default btn-xs" href="/permissions/{{ map.name }}/revoke_tag/{{ map.mapping_id }}">
+                                    <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span> Revoke
+                                    </a>
+                                {% endif %}
+                            {% endfor %}
+                            </td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+                {% if not mappings and not pending_requests %}
+                    <tr>
+                        <td colspan="5" class="text-center">
+                            <em>No permissions found.</em>
+                        </td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+        </div>
+        {% if can_grant %}
+        <div class='panel-footer'>
+            <a class="btn btn-default btn-sm" href="/permissions/grant_tag/{{ tag.name }}">
+                <span class="glyphicon glyphicon-plus"></span> Add Permission
+            </a>
+        </div>
+        {% endif %}
+    </div>
+{%- endmacro %}
+

--- a/grouper/fe/templates/permission-grant-tag.html
+++ b/grouper/fe/templates/permission-grant-tag.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/permissions">Permissions</a>
+{% endblock %}
+
+{% block subheading %}
+    Grant Permission to Tag {{ tag.name }}
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Grant Permission to Tag {{ tag.name }}</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/permissions/grant_tag/{{ tag.name }}">
+                {% include "forms/permission-grant.html" %}
+                <div class="form-permission">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/permission-revoke-tag.html
+++ b/grouper/fe/templates/permission-revoke-tag.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import format_tag %}
+
+
+{% block heading %}
+    <a href="/tags">Tags</a>
+{% endblock %}
+
+{% block subheading %}
+    Revoke Permission
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Revoke Permission</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/permissions/{{ mapping.permission.name}}/revoke_tag/{{ mapping.id }}">
+                <div class="form-group text-center">
+                    Revoke permission <strong>{{ mapping.permission.name }}:{{ mapping.argument }}</strong>
+                    from tag {{ format_tag(mapping.tag) }}</a>?
+                </div>
+                {{ xsrf_form() }}
+                <div class="form-group text-center">
+                    <button type="submit" class="btn btn-primary">Revoke Permission</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/public-key-add-tag.html
+++ b/grouper/fe/templates/public-key-add-tag.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/users">Users</a>
+{% endblock %}
+
+{% block subheading %}
+    Tag Public Key
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Tag Public Key</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/users/{{user.name}}/public-key/{{ key.id }}/tag">
+                <div class="form-group text-center">
+                    {% include "forms/public-key-add-tag.html" %}
+                </div>
+                {{ xsrf_form() }}
+                <div class="form-group text-center">
+                    <button type="submit" class="btn btn-primary">Add Tag</button>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/tag-edit.html
+++ b/grouper/fe/templates/tag-edit.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/groups">Tags</a>
+{% endblock %}
+
+{% block subheading %}
+    Edit ({{tag.name}})
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Edit Tag</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/tags/{{tag.name}}/edit">
+                {% include "forms/tag-edit.html" %}
+                <div class="form-tag">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/tag.html
+++ b/grouper/fe/templates/tag.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import group_panel, member_panel, tag_permission_panel, log_entry_panel,
+                                help_for, account %}
+
+{% block heading %}
+    <a href="/tags">Tags</a>
+{% endblock %}
+
+{% block headingbuttons %}
+    
+    <!-- If user is an owner of this tag, allow them to add permissions -->
+    {% if is_owner %}
+        <a href="/tags/{{tag.name}}/edit"
+           class="btn btn-primary"><i class="fa fa-edit"></i> Edit</a>
+    {% endif %}
+
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-6">
+        <blockquote><p>
+            <em>{{tag.description|default("&nbsp;", True)|escape}}</em>
+        </p></blockquote>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        {{ tag_permission_panel(390, permissions, tag, can_grant) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {{ log_entry_panel(390, log_entries) }}
+    </div>
+</div>
+
+{% endblock %}

--- a/grouper/fe/templates/tags.html
+++ b/grouper/fe/templates/tags.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import account, paginator, format_tag, dropdown with context %}
+
+{% block heading %}
+    Tags
+{% endblock %}
+
+{% block subheading %}
+    {{total}} tag(s)
+{% endblock %}
+
+{% block headingbuttons %}
+    {{ dropdown("limit", limit, [100, 250, 500]) }}
+    {{ paginator(offset, limit, total) }}
+      <button class="btn btn-success" data-toggle="modal" data-target="#createModal">
+          <i class="fa fa-plus"></i> Create
+      </button>
+{% endblock %}
+
+{% block content %}
+    <div class="col-md-10 col-md-offset-1">
+        <table class="table table-elist">
+            <thead>
+                <tr>
+                    <th class="col-sm-2">Tagname</th>
+                    <th class="col-sm-4">Description</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for tag in tags %}
+                <tr>
+                    <td>{{ format_tag(tag) }}</td>
+                    <td>{{tag.description|default("", True)|escape}}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+<div class="modal fade" id="createModal" tabindex="-1" role="dialog"
+      aria-labelledby="createModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Create Group</h4>
+           </div>
+            <div class="modal-body">
+                <form id="createForm" class="form-horizontal" role="form"
+                      method="post" action="/tags">
+                    {% include "forms/tag.html" %}
+            </div>
+            <div class="modal-footer">
+                <button id="formSubmit" type="submit" class="btn btn-primary">
+                    Submit
+                </button>
+            </div>
+                </form>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block script %}
+
+<script type="text/javascript">
+    $(function(){
+
+        $("#createModal").on("shown.bs.modal", function(){
+            $("#tagname").focus();
+        });
+        $("#formSubmit").click(function() {
+            $("#createFrom").submit();
+        });
+    });
+</script>
+{% endblock %}

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -1,5 +1,89 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import group_panel, public_key_panel, permission_panel, log_entry_panel, tokens_panel, shell_panel %}
+{% from 'macros/ui.html' import group_panel, permission_panel, log_entry_panel, tokens_panel, public_key_modal, shell_panel %}
+
+{% macro one_public_key_row(key, username, can_control) -%}
+    <td><span class="has-help" data-toggle="popover" data-content="{{ key.created_on|print_date }}">
+        {{ key.created_on|long_ago_str }}</span></td>
+    <td>{% if key.key_type %}{{ key.key_type }}{% endif %}</td>
+    <td>{% if key.key_size %}{{ key.key_size }}{% endif %}</td>
+    <td class="hidden-xs">
+        <code>{{ key.fingerprint }}</code>
+    </td>
+    <td>
+        {% for tag in key.tags() %}
+            {% if can_control %}
+            <form action="/users/{{ username }}/public-key/{{ key.id }}/delete_tag/{{ tag.id }}" method="post" style="display: inline">
+            {% endif %}
+                <button type="submit" class="btn btn-danger">
+                    {{ tag.name }}
+                </button>
+            {% if can_control %}
+                {{ xsrf_form() }}
+            </form>
+            {% endif %}
+        {% endfor %}
+    </td>
+    <td>
+        <span class="pull-right">
+        <button class="btn btn-default btn-xs public-key" key-body="{{ key.public_key|escape }}">
+            <i class="fa fa-search"></i>
+        </button>
+        <button class="btn btn-default btn-xs public-key" key-body="{{ ",".join(key.pretty_my_permissions())|escape }}">
+            <i class="fa fa-key"></i>
+        </button>
+    {% if can_control %}
+        <a class="btn btn-default btn-xs" href="/users/{{ username }}/public-key/{{ key.id }}/tag">
+            <span class="glyphicon glyphicon-tag" style="vertical-align: -1px"></span>
+        </a>
+        <a class="btn btn-default btn-xs" href="/users/{{ username }}/public-key/{{ key.id }}/delete">
+            <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span>
+        </a>
+        </span>
+    {% endif %}
+    </td>
+{%- endmacro %}
+
+{% macro public_key_panel(max_height, user, public_keys, can_control=False) -%}
+    {{ public_key_modal() }}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Public Keys</h3>
+        </div>
+        <div class="table-responsive" style="max-height: {{max_height}}px; overflow-y: auto">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-1">Age</th>
+                        <th class="col-sm-1">Type</th>
+                        <th class="col-sm-1">Size</th>
+                        <th class="col-sm-3 hidden-xs">Fingerprint</th>
+                        <th class="col-sm-1">Tags</th>
+                        <th class="col-sm-2"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for key in public_keys %}
+                    <tr>
+                        {{ one_public_key_row(key, user.name, can_control) }}
+                    </tr>
+                {% endfor %}
+                {% if not public_keys %}
+                    <tr>
+                        <td colspan="5" class="text-center"><em>No Public Keys</em></td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+            {% if can_control %}
+            <div class='panel-footer'>
+                <a class="btn btn-default btn-sm" href="/users/{{ user.name }}/public-key/add">
+                <span class="glyphicon glyphicon-plus"></span> Add Public Key
+                </a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+{%- endmacro %}
 
 {% block heading %}
     <a href="/users">Users</a>

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -10,7 +10,7 @@
         <code>{{ key.fingerprint }}</code>
     </td>
     <td>
-        {% for tag in key.tags() %}
+        {% for tag in key.tags %}
             {% if can_control %}
             <form action="/users/{{ username }}/public-key/{{ key.id }}/delete_tag/{{ tag.id }}" method="post" style="display: inline">
             {% endif %}
@@ -28,7 +28,7 @@
         <button class="btn btn-default btn-xs public-key" key-body="{{ key.public_key|escape }}">
             <i class="fa fa-search"></i>
         </button>
-        <button class="btn btn-default btn-xs public-key" key-body="{{ ",".join(key.pretty_my_permissions())|escape }}">
+        <button class="btn btn-default btn-xs public-key" key-body="{{ ",".join(key.pretty_permissions)|escape }}">
             <i class="fa fa-key"></i>
         </button>
     {% if can_control %}

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -15,6 +15,7 @@ from grouper.models.permission_map import PermissionMap
 from grouper.models.public_key import PublicKey
 from grouper.models.user import User
 from grouper.models.user_metadata import UserMetadata
+from grouper.public_key import get_public_key_permissions, get_public_key_tags
 from grouper.util import singleton
 
 
@@ -166,9 +167,9 @@ class GroupGraph(object):
                         "public_key": key.public_key,
                         "fingerprint": key.fingerprint,
                         "created_on": str(key.created_on),
-                        "tags": [tag.name for tag in key.tags()],
+                        "tags": [tag.name for tag in get_public_key_tags(session, key)],
                         "permissions": [(perm.name, perm.argument)
-                                        for perm in key.my_permissions()],
+                                        for perm in get_public_key_permissions(session, key)],
                     } for key in public_keys.get(user.id, [])
                 ],
                 "metadata": [

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -166,6 +166,9 @@ class GroupGraph(object):
                         "public_key": key.public_key,
                         "fingerprint": key.fingerprint,
                         "created_on": str(key.created_on),
+                        "tags": [tag.name for tag in key.tags()],
+                        "permissions": [(perm.name, perm.argument)
+                                        for perm in key.my_permissions()],
                     } for key in public_keys.get(user.id, [])
                 ],
                 "metadata": [

--- a/grouper/models/audit_log.py
+++ b/grouper/models/audit_log.py
@@ -46,6 +46,8 @@ class AuditLog(Model):
     on_group = relationship("Group", foreign_keys=[on_group_id])
     on_permission_id = Column(Integer, ForeignKey("permissions.id"), nullable=True)
     on_permission = relationship("Permission", foreign_keys=[on_permission_id])
+    on_tag_id = Column(Integer, ForeignKey("public_key_tags.id"), nullable=True)
+    on_tag = relationship("PublicKeyTag", foreign_keys=[on_tag_id])
 
     # The action and description columns are text. These are mostly displayed
     # to the user as-is, but we might provide filtering or something.
@@ -55,7 +57,7 @@ class AuditLog(Model):
 
     @staticmethod
     def log(session, actor_id, action, description,
-            on_user_id=None, on_group_id=None, on_permission_id=None,
+            on_user_id=None, on_group_id=None, on_permission_id=None, on_tag_id=None,
             category=AuditLogCategory.general):
         '''
         Log an event in the database.
@@ -78,6 +80,7 @@ class AuditLog(Model):
             on_user_id=on_user_id if on_user_id else None,
             on_group_id=on_group_id if on_group_id else None,
             on_permission_id=on_permission_id if on_permission_id else None,
+            on_tag_id=on_tag_id if on_tag_id else None,
             category=int(category),
         )
         try:
@@ -93,8 +96,8 @@ class AuditLog(Model):
 
     @staticmethod
     def get_entries(session, actor_id=None, on_user_id=None, on_group_id=None,
-                    on_permission_id=None, limit=None, offset=None, involve_user_id=None,
-                    category=None, action=None):
+                    on_permission_id=None, on_tag_id=None, limit=None, offset=None,
+                    involve_user_id=None, category=None, action=None):
         '''
         Flexible method for getting log entries. By default it returns all entries
         starting at the newest. Most recent first.
@@ -112,6 +115,8 @@ class AuditLog(Model):
             results = results.filter(AuditLog.on_group_id == on_group_id)
         if on_permission_id:
             results = results.filter(AuditLog.on_permission_id == on_permission_id)
+        if on_tag_id:
+            results = results.filter(AuditLog.on_tag_id == on_tag_id)
         if involve_user_id:
             results = results.filter(or_(
                 AuditLog.on_user_id == involve_user_id,

--- a/grouper/models/public_key.py
+++ b/grouper/models/public_key.py
@@ -7,62 +7,6 @@ from grouper.models.base.model_base import Model
 from grouper.models.public_key_tag_map import PublicKeyTagMap
 
 
-def _perm_list_to_dict(perms):
-    # type: List[Permission] -> Dict[str, Dict[str, Permission]]
-    """Converts a list of Permission objects into a dictionary indexed by the permission names.
-    That dictionary in turn holds another dictionary which is indexed by permission argument, and
-    stores the Permission object
-
-    Args:
-        perms: a list containing Permission objects
-
-    Returns:
-        a dictionary with the permission names as keys, and has as values another dictionary
-        with permission arguments as keys and Permission objects as values
-    """
-    ret = dict()
-    for perm in perms:
-        if perm.name not in ret:
-            ret[perm.name] = dict()
-        ret[perm.name][perm.argument] = perm
-    return ret
-
-
-def _permission_intersection(perms_a, perms_b):
-    # type: List[Permission], List[Permission] -> Set[Permission]
-    """Returns the intersection of the two Permission lists, taking into account the special
-    handling of argument wildcards
-
-    Args:
-        perms_a: the first list of permissions
-        perms_b: the second list of permissions
-
-    Returns:
-        a set of all permissions that both perms_a and perms_b grant access to
-    """
-    pdict_b = _perm_list_to_dict(perms_b)
-    ret = set()
-    for perm in perms_a:
-        if perm.name not in pdict_b:
-            continue
-        if perm.argument in pdict_b[perm.name]:
-            ret.add(perm)
-            continue
-        # Argument wildcard
-        if "*" in pdict_b[perm.name]:
-            ret.add(perm)
-            continue
-        # According to Group.has_permission, None as an argument counts as a wildcard too
-        if None in pdict_b[perm.name]:
-            ret.add(perm)
-            continue
-        # If this permission is a wildcard, we add all permissions with the same name from
-        # the other set
-        if perm.argument == "*" or perm.argument is None:
-            ret |= {p for p in pdict_b[perm.name].values()}
-    return ret
-
-
 class PublicKey(Model):
 
     __tablename__ = "public_keys"
@@ -97,9 +41,12 @@ class PublicKey(Model):
         Returns:
             a list of all permissions this public key has
         """
+        from grouper.permissions import permission_intersection
+        # TODO: Fix underlying circular dependency
+
         my_perms = self.user.my_permissions()
         for tag in self.tags():
-            my_perms = _permission_intersection(my_perms, tag.my_permissions())
+            my_perms = permission_intersection(my_perms, tag.my_permissions())
 
         return list(my_perms)
 

--- a/grouper/models/public_key.py
+++ b/grouper/models/public_key.py
@@ -4,6 +4,63 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 
 from grouper.models.base.model_base import Model
+from grouper.models.public_key_tag_map import PublicKeyTagMap
+
+
+def _perm_list_to_dict(perms):
+    # type: List[Permission] -> Dict[str, Dict[str, Permission]]
+    """Converts a list of Permission objects into a dictionary indexed by the permission names.
+    That dictionary in turn holds another dictionary which is indexed by permission argument, and
+    stores the Permission object
+
+    Args:
+        perms: a list containing Permission objects
+
+    Returns:
+        a dictionary with the permission names as keys, and has as values another dictionary
+        with permission arguments as keys and Permission objects as values
+    """
+    ret = dict()
+    for perm in perms:
+        if perm.name not in ret:
+            ret[perm.name] = dict()
+        ret[perm.name][perm.argument] = perm
+    return ret
+
+
+def _permission_intersection(perms_a, perms_b):
+    # type: List[Permission], List[Permission] -> Set[Permission]
+    """Returns the intersection of the two Permission lists, taking into account the special
+    handling of argument wildcards
+
+    Args:
+        perms_a: the first list of permissions
+        perms_b: the second list of permissions
+
+    Returns:
+        a set of all permissions that both perms_a and perms_b grant access to
+    """
+    pdict_b = _perm_list_to_dict(perms_b)
+    ret = set()
+    for perm in perms_a:
+        if perm.name not in pdict_b:
+            continue
+        if perm.argument in pdict_b[perm.name]:
+            ret.add(perm)
+            continue
+        # Argument wildcard
+        if "*" in pdict_b[perm.name]:
+            ret.add(perm)
+            continue
+        # According to Group.has_permission, None as an argument counts as a wildcard too
+        if None in pdict_b[perm.name]:
+            ret.add(perm)
+            continue
+        # If this permission is a wildcard, we add all permissions with the same name from
+        # the other set
+        if perm.argument == "*" or perm.argument is None:
+            ret |= {p for p in pdict_b[perm.name].values()}
+    return ret
 
 
 class PublicKey(Model):
@@ -20,3 +77,35 @@ class PublicKey(Model):
     public_key = Column(Text, nullable=False)
     fingerprint = Column(String(length=64), nullable=False, unique=True)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    def tags(self):
+        # type: () -> List[PublicKeyTag]
+        """Returns the list of tags that are assigned to this public key
+
+        Returns:
+            a list that contains all of the PublicKeyTags that are assigned to this public key
+        """
+        mappings = self.session.query(PublicKeyTagMap).filter_by(key_id=self.id).all()
+        return [mapping.tag for mapping in mappings]
+
+    def my_permissions(self):
+        # type: () -> List[Permission]
+        """Returns the permissions that this public key has. Namely, this the set of permissions
+        that the public key's owner has, intersected with the permissions allowed by this key's
+        tags
+
+        Returns:
+            a list of all permissions this public key has
+        """
+        my_perms = self.user.my_permissions()
+        for tag in self.tags():
+            my_perms = _permission_intersection(my_perms, tag.my_permissions())
+
+        return list(my_perms)
+
+    def pretty_my_permissions(self):
+        # type: () -> List[str]
+        """Returns a list of this public key's permissions formatted nicely as strings because
+        tyleromeara@ got tired of figuring out how to do this in Jinja."""
+        return ["{} ({})".format(perm.name, perm.argument if perm.argument else "unargumented")
+               for perm in self.my_permissions()]

--- a/grouper/models/public_key.py
+++ b/grouper/models/public_key.py
@@ -4,7 +4,6 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 
 from grouper.models.base.model_base import Model
-from grouper.models.public_key_tag_map import PublicKeyTagMap
 
 
 class PublicKey(Model):
@@ -21,38 +20,3 @@ class PublicKey(Model):
     public_key = Column(Text, nullable=False)
     fingerprint = Column(String(length=64), nullable=False, unique=True)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
-
-    def tags(self):
-        # type: () -> List[PublicKeyTag]
-        """Returns the list of tags that are assigned to this public key
-
-        Returns:
-            a list that contains all of the PublicKeyTags that are assigned to this public key
-        """
-        mappings = self.session.query(PublicKeyTagMap).filter_by(key_id=self.id).all()
-        return [mapping.tag for mapping in mappings]
-
-    def my_permissions(self):
-        # type: () -> List[Permission]
-        """Returns the permissions that this public key has. Namely, this the set of permissions
-        that the public key's owner has, intersected with the permissions allowed by this key's
-        tags
-
-        Returns:
-            a list of all permissions this public key has
-        """
-        from grouper.permissions import permission_intersection
-        # TODO: Fix underlying circular dependency
-
-        my_perms = self.user.my_permissions()
-        for tag in self.tags():
-            my_perms = permission_intersection(my_perms, tag.my_permissions())
-
-        return list(my_perms)
-
-    def pretty_my_permissions(self):
-        # type: () -> List[str]
-        """Returns a list of this public key's permissions formatted nicely as strings because
-        tyleromeara@ got tired of figuring out how to do this in Jinja."""
-        return ["{} ({})".format(perm.name, perm.argument if perm.argument else "unargumented")
-               for perm in self.my_permissions()]

--- a/grouper/models/public_key_tag.py
+++ b/grouper/models/public_key_tag.py
@@ -25,7 +25,7 @@ class PublicKeyTag(Model):
 
     @staticmethod
     def get(session, id=None, name=None):
-        # type: Session, int, str -> PublicKeyTag
+        # type: (Session, int, str) -> PublicKeyTag
         if id:
             return session.query(PublicKeyTag).filter_by(id=id).scalar()
         if name:

--- a/grouper/models/public_key_tag.py
+++ b/grouper/models/public_key_tag.py
@@ -1,10 +1,11 @@
-from sqlalchemy import Column, Integer, String, Text, Boolean
-from grouper.models.base.model_base import Model
-from grouper.constants import MAX_NAME_LENGTH
-from grouper.models.tag_permission_map import TagPermissionMap
-from grouper.models.permission import Permission
+from sqlalchemy import Boolean, Column, Integer, String, Text
 from sqlalchemy.sql import label
+
+from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.audit_log import AuditLog
+from grouper.models.base.model_base import Model
+from grouper.models.permission import Permission
+from grouper.models.tag_permission_map import TagPermissionMap
 
 
 class PublicKeyTag(Model):

--- a/grouper/models/public_key_tag.py
+++ b/grouper/models/public_key_tag.py
@@ -1,0 +1,54 @@
+from sqlalchemy import Column, Integer, String, Text
+from grouper.models.base.model_base import Model
+from grouper.constants import MAX_NAME_LENGTH
+from grouper.models.tag_permission_map import TagPermissionMap
+from grouper.models.permission import Permission
+from sqlalchemy.sql import label
+from grouper.models.audit_log import AuditLog
+
+
+class PublicKeyTag(Model):
+
+    __tablename__ = "public_key_tags"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(length=MAX_NAME_LENGTH), unique=True)
+    description = Column(Text)
+
+    def my_permissions(self):
+        """Returns the permissions granted to this tag.
+
+        Returns:
+            A list of namedtuple with the id, name, mapping_id, argument, and granted_on for each
+            permission
+        """
+        permissions = self.session.query(
+            Permission.id,
+            Permission.name,
+            label("mapping_id", TagPermissionMap.id),
+            TagPermissionMap.argument,
+            TagPermissionMap.granted_on,
+        ).filter(
+            TagPermissionMap.permission_id == Permission.id,
+            TagPermissionMap.tag_id == self.id,
+        ).all()
+
+        return permissions
+
+    def my_log_entries(self):
+        # type: () -> List[AuditLog]
+        """Returns the 20 most recent audit log entries involving this tag
+
+        Returns:
+            a list of AuditLog entries
+        """
+        return AuditLog.get_entries(self.session, on_tag_id=self.id, limit=20)
+
+    @staticmethod
+    def get(session, id=None, name=None):
+        # type: Session, int, str -> PublicKeyTag
+        if id:
+            return session.query(PublicKeyTag).filter_by(id=id).scalar()
+        if name:
+            return session.query(PublicKeyTag).filter_by(name=name).scalar()
+        return None

--- a/grouper/models/public_key_tag.py
+++ b/grouper/models/public_key_tag.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text
+from sqlalchemy import Column, Integer, String, Text, Boolean
 from grouper.models.base.model_base import Model
 from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.tag_permission_map import TagPermissionMap
@@ -14,6 +14,7 @@ class PublicKeyTag(Model):
     id = Column(Integer, primary_key=True)
     name = Column(String(length=MAX_NAME_LENGTH), unique=True)
     description = Column(Text)
+    enabled = Column(Boolean, default=True)
 
     def my_permissions(self):
         """Returns the permissions granted to this tag.

--- a/grouper/models/public_key_tag.py
+++ b/grouper/models/public_key_tag.py
@@ -1,11 +1,8 @@
 from sqlalchemy import Boolean, Column, Integer, String, Text
-from sqlalchemy.sql import label
 
 from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.audit_log import AuditLog
 from grouper.models.base.model_base import Model
-from grouper.models.permission import Permission
-from grouper.models.tag_permission_map import TagPermissionMap
 
 
 class PublicKeyTag(Model):
@@ -16,26 +13,6 @@ class PublicKeyTag(Model):
     name = Column(String(length=MAX_NAME_LENGTH), unique=True)
     description = Column(Text)
     enabled = Column(Boolean, default=True)
-
-    def my_permissions(self):
-        """Returns the permissions granted to this tag.
-
-        Returns:
-            A list of namedtuple with the id, name, mapping_id, argument, and granted_on for each
-            permission
-        """
-        permissions = self.session.query(
-            Permission.id,
-            Permission.name,
-            label("mapping_id", TagPermissionMap.id),
-            TagPermissionMap.argument,
-            TagPermissionMap.granted_on,
-        ).filter(
-            TagPermissionMap.permission_id == Permission.id,
-            TagPermissionMap.tag_id == self.id,
-        ).all()
-
-        return permissions
 
     def my_log_entries(self):
         # type: () -> List[AuditLog]

--- a/grouper/models/public_key_tag_map.py
+++ b/grouper/models/public_key_tag_map.py
@@ -28,7 +28,7 @@ class PublicKeyTagMap(Model):
 
     @staticmethod
     def get(session, id=None):
-        # type: Session, int -> PublicKeyTagMap
+        # type: (Session, int) -> PublicKeyTagMap
         if id is not None:
             return session.query(PublicKeyTagMap).filter_by(id=id).scalar()
         return None

--- a/grouper/models/public_key_tag_map.py
+++ b/grouper/models/public_key_tag_map.py
@@ -1,6 +1,8 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, UniqueConstraint, ForeignKey, DateTime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, UniqueConstraint
 from sqlalchemy.orm import relationship
+
 from grouper.models.base.model_base import Model
 from grouper.models.public_key_tag import PublicKeyTag
 

--- a/grouper/models/public_key_tag_map.py
+++ b/grouper/models/public_key_tag_map.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, UniqueConstraint, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from grouper.models.base.model_base import Model
+from grouper.models.public_key_tag import PublicKeyTag
+
+
+class PublicKeyTagMap(Model):
+    """
+    Maps a relationship between a Public Key and a Tag.
+    """
+    __tablename__ = "tag_public_key_map"
+    __table_args__ = (
+        UniqueConstraint('tag_id', 'key_id', name='uidx1'),
+    )
+
+    id = Column(Integer, primary_key=True)
+
+    tag_id = Column(Integer, ForeignKey("public_key_tags.id"), nullable=False)
+    tag = relationship(PublicKeyTag, foreign_keys=[tag_id])
+
+    key_id = Column(Integer, ForeignKey("public_keys.id"), nullable=False)
+    key = relationship("PublicKey", foreign_keys=[key_id])
+
+    granted_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    @staticmethod
+    def get(session, id=None):
+        # type: Session, int -> PublicKeyTagMap
+        if id is not None:
+            return session.query(PublicKeyTagMap).filter_by(id=id).scalar()
+        return None

--- a/grouper/models/tag_permission_map.py
+++ b/grouper/models/tag_permission_map.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, UniqueConstraint, ForeignKey, DateTime
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from grouper.constants import MAX_NAME_LENGTH

--- a/grouper/models/tag_permission_map.py
+++ b/grouper/models/tag_permission_map.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, UniqueConstraint, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+
+from grouper.constants import MAX_NAME_LENGTH
+from grouper.models.base.model_base import Model
+
+
+class TagPermissionMap(Model):
+    """
+    Maps a relationship between a Permission and a Tag. Note that a single permission can be
+    mapped into a given tag multiple times, as long as the argument is unique.
+
+    These include the optional arguments, which can either be a string, an asterisks ("*"), or
+    Null to indicate no argument.
+    """
+    __tablename__ = "tag_permissions_map"
+    __table_args__ = (
+        UniqueConstraint('permission_id', 'tag_id', 'argument', name='uidx1'),
+    )
+
+    id = Column(Integer, primary_key=True)
+
+    permission_id = Column(Integer, ForeignKey("permissions.id"), nullable=False)
+    permission = relationship("Permission", foreign_keys=[permission_id])
+
+    tag_id = Column(Integer, ForeignKey("public_key_tags.id"), nullable=False)
+    tag = relationship("PublicKeyTag", foreign_keys=[tag_id])
+
+    argument = Column(String(length=MAX_NAME_LENGTH), nullable=True)
+    granted_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    @staticmethod
+    def get(session, id=None):
+        # type: Session, int -> TagPermissionMap
+        if id is not None:
+            return session.query(TagPermissionMap).filter_by(id=id).scalar()
+        return None

--- a/grouper/models/tag_permission_map.py
+++ b/grouper/models/tag_permission_map.py
@@ -33,7 +33,7 @@ class TagPermissionMap(Model):
 
     @staticmethod
     def get(session, id=None):
-        # type: Session, int -> TagPermissionMap
+        # type: (Session, int) -> TagPermissionMap
         if id is not None:
             return session.query(TagPermissionMap).filter_by(id=id).scalar()
         return None

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -63,7 +63,7 @@ def grant_permission(session, group_id, permission_id, argument=''):
 
 
 def grant_permission_to_tag(session, tag_id, permission_id, argument=''):
-    # type: Session, int, int, str -> None
+    # type: (Session, int, int, str) -> boolean
     """
     Grant a permission to this tag. This will fail if the (permission, argument) has already
     been granted to this tag.
@@ -607,7 +607,7 @@ def update_request(session, request, user, new_status, comment):
 
 
 def permission_list_to_dict(perms):
-    # type: List[Permission] -> Dict[str, Dict[str, Permission]]
+    # type: (List[Permission]) -> Dict[str, Dict[str, Permission]]
     """Converts a list of Permission objects into a dictionary indexed by the permission names.
     That dictionary in turn holds another dictionary which is indexed by permission argument, and
     stores the Permission object
@@ -626,7 +626,7 @@ def permission_list_to_dict(perms):
 
 
 def permission_intersection(perms_a, perms_b):
-    # type: List[Permission], List[Permission] -> Set[Permission]
+    # type: (List[Permission], List[Permission]) -> Set[Permission]
     """Returns the intersection of the two Permission lists, taking into account the special
     handling of argument wildcards
 

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -19,6 +19,7 @@ from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.permission_request import PermissionRequest
 from grouper.models.permission_request_status_change import PermissionRequestStatusChange
+from grouper.models.tag_permission_map import TagPermissionMap
 from grouper.plugin import get_plugins
 from grouper.util import matches_glob
 
@@ -54,6 +55,31 @@ def grant_permission(session, group_id, permission_id, argument=''):
     assert re.match(ARGUMENT_VALIDATION, argument), 'Permission argument does not match regex.'
 
     mapping = PermissionMap(permission_id=permission_id, group_id=group_id, argument=argument)
+    mapping.add(session)
+
+    Counter.incr(session, "updates")
+
+    session.commit()
+
+
+def grant_permission_to_tag(session, tag_id, permission_id, argument=''):
+    # type: Session, int, int, str -> None
+    """
+    Grant a permission to this tag. This will fail if the (permission, argument) has already
+    been granted to this tag.
+
+    Args:
+        session(models.base.session.Sessioan): database session
+        tag_id(int): the id of the tag we're granting the permission to
+        permission_id(int): the id of the permission to be granted
+        argument(str): must match constants.ARGUMENT_VALIDATION
+
+    Throws:
+        AssertError if argument does not match ARGUMENT_VALIDATION regex
+    """
+    assert re.match(ARGUMENT_VALIDATION, argument), 'Permission argument does not match regex.'
+
+    mapping = TagPermissionMap(permission_id=permission_id, tag_id=tag_id, argument=argument)
     mapping.add(session)
 
     Counter.incr(session, "updates")

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -121,7 +121,7 @@ def get_public_keys_of_user(session, user_id):
 
 
 def add_tag_to_public_key(session, public_key, tag):
-    # type: Session, PublicKey, PublicKeyTag -> None
+    # type: (Session, PublicKey, PublicKeyTag) -> None
     """Assigns the tag to the given public key.
 
     Args:
@@ -143,7 +143,7 @@ def add_tag_to_public_key(session, public_key, tag):
 
 
 def remove_tag_from_public_key(session, public_key, tag):
-    # type: Session, PublicKey, PublicKeyTag -> None
+    # type: (Session, PublicKey, PublicKeyTag) -> None
     """Removes the tag from the given public key.
 
     Args:
@@ -165,7 +165,7 @@ def remove_tag_from_public_key(session, public_key, tag):
 
 
 def get_public_key_tags(session, public_key):
-    # type: Session, PublicKey -> List[PublicKeyTag]
+    # type: (Session, PublicKey) -> List[PublicKeyTag]
     """Returns the list of tags that are assigned to this public key
 
     Returns:
@@ -176,7 +176,7 @@ def get_public_key_tags(session, public_key):
 
 
 def get_public_key_permissions(session, public_key):
-        # type: Session, PublicKey -> List[Permission]
+        # type: (Session, PublicKey) -> List[Permission]
         """Returns the permissions that this public key has. Namely, this the set of permissions
         that the public key's owner has, intersected with the permissions allowed by this key's
         tags

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -6,6 +6,7 @@ from sshpubkey.exc import PublicKeyParseError  # noqa
 from grouper.models.counter import Counter
 from grouper.models.permission import Permission
 from grouper.models.public_key import PublicKey
+from grouper.models.public_key_tag import PublicKeyTag  # noqa
 from grouper.models.public_key_tag_map import PublicKeyTagMap
 from grouper.models.tag_permission_map import TagPermissionMap
 from grouper.user_permissions import user_permissions

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -4,9 +4,14 @@ from sshpubkey.exc import PublicKeyParseError  # noqa
 
 from grouper.models.counter import Counter
 from grouper.models.public_key import PublicKey
+from grouper.models.public_key_tag_map import PublicKeyTagMap
 
 
 class DuplicateKey(Exception):
+    pass
+
+
+class DuplicateTag(Exception):
     pass
 
 
@@ -14,6 +19,11 @@ class KeyNotFound(Exception):
     key_id = None
     user_id = None
     """Particular user's specific key was not found."""
+
+
+class TagNotOnKey(Exception):
+    key_id = None
+    tag_id = None
 
 
 def get_public_key(session, user_id, key_id):
@@ -79,6 +89,11 @@ def delete_public_key(session, user_id, key_id):
         KeyNotFound if specified key wasn't found
     """
     pkey = get_public_key(session, user_id, key_id)
+
+    tags = session.query(PublicKeyTagMap).filter_by(key_id=key_id).all()
+    for tag in tags:
+        remove_tag_from_public_key(session, pkey, tag)
+
     pkey.delete(session)
 
     Counter.incr(session, "updates")
@@ -98,3 +113,45 @@ def get_public_keys_of_user(session, user_id):
     """
     pkey = session.query(PublicKey).filter_by(user_id=user_id).all()
     return pkey
+
+
+def add_tag_to_public_key(session, public_key, tag):
+    # type: Session, PublicKey, PublicKeyTag -> None
+    """Assigns the tag to the given public key.
+
+    Args:
+        session(models.base.session.Session): database session
+        public_key(models.public_key.PublicKey): the public key to be tagged
+        tag(models.public_key_tag.PublicKeyTag): the tag to be assigned to the public key
+
+    Throws:
+        DuplicateTag if the tag was already assigned to the public key
+    """
+    mapping = PublicKeyTagMap(tag_id=tag.id, key_id=public_key.id)
+    try:
+        mapping.add(session)
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        raise DuplicateTag()
+
+
+def remove_tag_from_public_key(session, public_key, tag):
+    # type: Session, PublicKey, PublicKeyTag -> None
+    """Removes the tag from the given public key.
+
+    Args:
+        session(models.base.session.Session): database session
+        public_key(models.public_key.PublicKey): the public key to be tagged
+        tag(models.public_key_tag.PublicKeyTag): the tag to be assigned to the public key
+
+    Throws:
+        TagNotOnKey if the tag was already assigned to the public key
+    """
+    mapping = session.query(PublicKeyTagMap).filter_by(tag_id=tag.id, key_id=public_key.id).scalar()
+
+    if not mapping:
+        raise TagNotOnKey()
+
+    mapping.delete(session)
+    session.commit()

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -130,6 +130,7 @@ def add_tag_to_public_key(session, public_key, tag):
     mapping = PublicKeyTagMap(tag_id=tag.id, key_id=public_key.id)
     try:
         mapping.add(session)
+        Counter.incr(session, "updates")
         session.commit()
     except IntegrityError:
         session.rollback()
@@ -154,4 +155,5 @@ def remove_tag_from_public_key(session, public_key, tag):
         raise TagNotOnKey()
 
     mapping.delete(session)
+    Counter.incr(session, "updates")
     session.commit()

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -8,6 +8,7 @@ from grouper.models.permission import Permission
 from grouper.models.public_key import PublicKey
 from grouper.models.public_key_tag_map import PublicKeyTagMap
 from grouper.models.tag_permission_map import TagPermissionMap
+from grouper.user_permissions import user_permissions
 
 
 class DuplicateKey(Exception):
@@ -185,7 +186,7 @@ def get_public_key_permissions(session, public_key):
         """
         # TODO: Fix circular dependency
         from grouper.permissions import permission_intersection
-        my_perms = public_key.user.my_permissions()
+        my_perms = user_permissions(session, public_key.user)
         for tag in get_public_key_tags(session, public_key):
             my_perms = permission_intersection(my_perms,
                 get_public_key_tag_permissions(session, tag))

--- a/grouper/user.py
+++ b/grouper/user.py
@@ -56,7 +56,7 @@ def get_all_users(session):
 
 
 def get_all_enabled_users(session):
-    # type: Session -> List[User]
+    # type: (Session) -> List[User]
     """Returns all enabled users in the database.
 
     At present, this is not cached at all and returns the full list of

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -6,28 +6,12 @@ import pytest
 
 from fixtures import api_app as app  # noqa
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
-from grouper.constants import TAG_EDIT, USER_METADATA_SHELL_KEY
-from grouper.model_soup import Group
-from grouper.models.permission import Permission
-from grouper.models.public_key import PublicKey
-from grouper.models.public_key_tag import PublicKeyTag
-from grouper.models.user import User
+from grouper.constants import USER_METADATA_SHELL_KEY
 from grouper.models.user_token import UserToken
-from grouper.permissions import grant_permission_to_tag
-from grouper.public_key import add_public_key, add_tag_to_public_key, get_public_key_permissions
-from grouper.user_permissions import user_permissions
 from grouper.user_metadata import get_user_metadata_by_key, set_user_metadata
 from grouper.user_token import add_new_user_token, disable_user_token
 from url_util import url
 from util import grant_permission
-
-
-key1 = ('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCUQeasspT/etEJR2WUoR+h2sMOQYbJgr0Q'
-            'E+J8p97gEhmz107KWZ+3mbOwyIFzfWBcJZCEg9wy5Paj+YxbGONqbpXAhPdVQ2TLgxr41bNXvbcR'
-            'AxZC+Q12UZywR4Klb2kungKz4qkcmSZzouaKK12UxzGB3xQ0N+3osKFj3xA1+B6HqrVreU19XdVo'
-            'AJh0xLZwhw17/NDM+dAcEdMZ9V89KyjwjraXtOVfFhQF0EDF0ame8d6UkayGrAiXC2He0P2Cja+J'
-            '371P27AlNLHFJij8WGxvcGGSeAxMLoVSDOOllLCYH5UieV8mNpX1kNe2LeA58ciZb0AXHaipSmCH'
-            'gh/ some-comment')
 
 
 @pytest.mark.gen_test
@@ -196,58 +180,3 @@ def test_shell(session, users, http_client, base_url, graph):
     assert body["data"]["user"]["metadata"][0]["data_key"] == "shell", "There should only be 1 metadata!"
     assert body["data"]["user"]["metadata"][0]["data_value"] == "/bin/zsh", "The shell should be set to the correct value"
     assert len(body["data"]["user"]["metadata"]) == 1, "There should only be 1 metadata!"
-
-
-@pytest.mark.gen_test
-def test_tags(session, users, http_client, base_url, graph):
-    user = session.query(User).filter_by(username="testuser@a.co").scalar()
-
-    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
-    perm.add(session)
-    session.commit()
-
-    perm2 = Permission(name="it.literally.does.not.matter", description="Why is this not nullable?")
-    perm2.add(session)
-    session.commit()
-
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name="it.literally.does.not.matter").scalar(), "*")
-
-    tag = PublicKeyTag(name="tyler_was_here")
-    tag.add(session)
-    session.commit()
-
-    tag = PublicKeyTag.get(session, name="tyler_was_here")
-
-    user = session.query(User).filter_by(username="testuser@a.co").scalar()
-
-    grant_permission_to_tag(session, tag.id, perm.id, "prod")
-
-    user = session.query(User).filter_by(username="testuser@a.co").scalar()
-
-    add_public_key(session, user, key1)
-
-    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
-    user = session.query(User).filter_by(username="testuser@a.co").scalar()
-
-    add_tag_to_public_key(session, key, tag)
-
-    user = session.query(User).filter_by(username="testuser@a.co").scalar()
-
-    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
-    assert len(get_public_key_permissions(session, key)) == 1, "The SSH Key should have only 1 permission"
-    assert get_public_key_permissions(session, key)[0].name == TAG_EDIT, "The SSH key's permission should be TAG_EDIT"
-    assert get_public_key_permissions(session, key)[0].argument == "prod", "The SSH key's permission argument should be restricted to the tag's argument"
-    assert len(user_permissions(session, user)) > 1, "The user should have more than 1 permission"
-
-    graph.update_from_db(session)
-
-    fe_url = url(base_url, '/users/{}'.format(user.username))
-    resp = yield http_client.fetch(fe_url)
-    assert resp.code == 200
-    body = json.loads(resp.body)
-    pub_key = body['data']['user']['public_keys'][0]
-    assert len(pub_key['tags']) == 1, "The public key should only have 1 tag"
-    assert pub_key['tags'][0] == 'tyler_was_here', "The public key should have the tag we gave it"
-    assert len(pub_key['permissions']) == 1, "The public key should only have 1 permission"
-    assert pub_key['permissions'][0] == [TAG_EDIT, "prod"], "The public key should only have permissions that are the intersection of the user's permissions and the tag's permissions"

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -6,11 +6,28 @@ import pytest
 
 from fixtures import api_app as app  # noqa
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
-from grouper.constants import USER_METADATA_SHELL_KEY
+from grouper.constants import TAG_EDIT, USER_METADATA_SHELL_KEY
+from grouper.model_soup import Group
+from grouper.models.permission import Permission
+from grouper.models.public_key import PublicKey
+from grouper.models.public_key_tag import PublicKeyTag
+from grouper.models.user import User
 from grouper.models.user_token import UserToken
+from grouper.permissions import grant_permission_to_tag
+from grouper.public_key import add_public_key, add_tag_to_public_key, get_public_key_permissions
+from grouper.user_permissions import user_permissions
 from grouper.user_metadata import get_user_metadata_by_key, set_user_metadata
 from grouper.user_token import add_new_user_token, disable_user_token
 from url_util import url
+from util import grant_permission
+
+
+key1 = ('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCUQeasspT/etEJR2WUoR+h2sMOQYbJgr0Q'
+            'E+J8p97gEhmz107KWZ+3mbOwyIFzfWBcJZCEg9wy5Paj+YxbGONqbpXAhPdVQ2TLgxr41bNXvbcR'
+            'AxZC+Q12UZywR4Klb2kungKz4qkcmSZzouaKK12UxzGB3xQ0N+3osKFj3xA1+B6HqrVreU19XdVo'
+            'AJh0xLZwhw17/NDM+dAcEdMZ9V89KyjwjraXtOVfFhQF0EDF0ame8d6UkayGrAiXC2He0P2Cja+J'
+            '371P27AlNLHFJij8WGxvcGGSeAxMLoVSDOOllLCYH5UieV8mNpX1kNe2LeA58ciZb0AXHaipSmCH'
+            'gh/ some-comment')
 
 
 @pytest.mark.gen_test
@@ -179,3 +196,58 @@ def test_shell(session, users, http_client, base_url, graph):
     assert body["data"]["user"]["metadata"][0]["data_key"] == "shell", "There should only be 1 metadata!"
     assert body["data"]["user"]["metadata"][0]["data_value"] == "/bin/zsh", "The shell should be set to the correct value"
     assert len(body["data"]["user"]["metadata"]) == 1, "There should only be 1 metadata!"
+
+
+@pytest.mark.gen_test
+def test_tags(session, users, http_client, base_url, graph):
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
+    perm.add(session)
+    session.commit()
+
+    perm2 = Permission(name="it.literally.does.not.matter", description="Why is this not nullable?")
+    perm2.add(session)
+    session.commit()
+
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name="it.literally.does.not.matter").scalar(), "*")
+
+    tag = PublicKeyTag(name="tyler_was_here")
+    tag.add(session)
+    session.commit()
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    grant_permission_to_tag(session, tag.id, perm.id, "prod")
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    add_public_key(session, user, key1)
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    add_tag_to_public_key(session, key, tag)
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+    assert len(get_public_key_permissions(session, key)) == 1, "The SSH Key should have only 1 permission"
+    assert get_public_key_permissions(session, key)[0].name == TAG_EDIT, "The SSH key's permission should be TAG_EDIT"
+    assert get_public_key_permissions(session, key)[0].argument == "prod", "The SSH key's permission argument should be restricted to the tag's argument"
+    assert len(user_permissions(session, user)) > 1, "The user should have more than 1 permission"
+
+    graph.update_from_db(session)
+
+    fe_url = url(base_url, '/users/{}'.format(user.username))
+    resp = yield http_client.fetch(fe_url)
+    assert resp.code == 200
+    body = json.loads(resp.body)
+    pub_key = body['data']['user']['public_keys'][0]
+    assert len(pub_key['tags']) == 1, "The public key should only have 1 tag"
+    assert pub_key['tags'][0] == 'tyler_was_here', "The public key should have the tag we gave it"
+    assert len(pub_key['permissions']) == 1, "The public key should only have 1 permission"
+    assert pub_key['permissions'][0] == [TAG_EDIT, "prod"], "The public key should only have permissions that are the intersection of the user's permissions and the tag's permissions"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,391 @@
+from datetime import date, timedelta
+from urllib import urlencode
+
+import pytest
+from tornado.httpclient import HTTPError
+
+from fixtures import fe_app as app
+from fixtures import standard_graph, users, graph, groups, session, permissions  # noqa
+from grouper.model_soup import Group, User
+from grouper.models.public_key import PublicKey, _permission_intersection
+from grouper.models.public_key_tag import PublicKeyTag
+from grouper.models.permission import Permission
+from grouper.constants import TAG_EDIT
+from url_util import url
+from util import get_users, get_groups, add_member, grant_permission
+from collections import namedtuple
+
+
+key_1 = ('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCUQeasspT/etEJR2WUoR+h2sMOQYbJgr0Q'
+            'E+J8p97gEhmz107KWZ+3mbOwyIFzfWBcJZCEg9wy5Paj+YxbGONqbpXAhPdVQ2TLgxr41bNXvbcR'
+            'AxZC+Q12UZywR4Klb2kungKz4qkcmSZzouaKK12UxzGB3xQ0N+3osKFj3xA1+B6HqrVreU19XdVo'
+            'AJh0xLZwhw17/NDM+dAcEdMZ9V89KyjwjraXtOVfFhQF0EDF0ame8d6UkayGrAiXC2He0P2Cja+J'
+            '371P27AlNLHFJij8WGxvcGGSeAxMLoVSDOOllLCYH5UieV8mNpX1kNe2LeA58ciZb0AXHaipSmCH'
+            'gh/ some-comment')
+
+key_2 = ("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDF1DyXlqc40AVUgt/IO0GFcTniaoFt5qCUAeNVlva"
+         "lMnsrRULIXkb0g1ds9P9/UI2jWr70ZYG7XieQX1F7NpzaDeUyPGCrLV1/ev1ZtUImCrDFfMznEjkcqB"
+         "33mRe1rCFGKNVOYUviPE1yBdbfZBGUuJBX2GOXQQj9fU4Hiq3rAgOhz89717mt+qZxZllZ4mdyVEaMB"
+         "WCwqAvl7Z5ecDjB+llFpBORTmsT8OZoGbZnJTIB1d9j0tSbegP17emE+g9fTrk4/ePmSIAKcSV3xj6h"
+         "98AGesNibyu9eKVrroEptxX4crl0o95Me6B1/DCL632xrTO0a5mSmlF4cxCgjLj9 to/ key2")
+
+
+@pytest.mark.gen_test
+def test_create_tag(users, http_client, base_url, session):
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+    assert tag is not None, "The tag should be created"
+    assert tag.name == "tyler_was_here", "The tag's name should be tyler_was_here"
+
+
+@pytest.mark.gen_test
+def test_add_tag(users, http_client, base_url, session):
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    # add SSH key
+    fe_url = url(base_url, '/users/{}/public-key/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'public_key': key_1}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+
+    # add SSH key
+    fe_url = url(base_url, '/users/{}/public-key/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'public_key': key_2}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    key2 = session.query(PublicKey).filter_by(public_key=key_2).scalar()
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    assert key.tags() == [], "No public keys should have a tag unless it's been added to the key"
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "dont_tag_me_bro", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag = PublicKeyTag.get(session, name="dont_tag_me_bro")
+
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    assert key.tags() == [], "No public keys should have a tag unless it's been added to the key"
+
+    fe_url = url(base_url, '/users/{}/public-key/{}/tag'.format(user.username, key.id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here"}),
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    assert len(key.tags()) == 1, "The key should have exactly 1 tag"
+    assert key.tags()[0].name == "tyler_was_here"
+
+    key2 = session.query(PublicKey).filter_by(public_key=key_2).scalar()
+    assert len(key2.tags()) == 0, "Keys other than the one with the added tag should not gain tags"
+
+@pytest.mark.gen_test
+def test_remove_tag(users, http_client, base_url, session):
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    # add SSH key
+    fe_url = url(base_url, '/users/{}/public-key/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'public_key': key_1}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+
+    # add SSH key
+    fe_url = url(base_url, '/users/{}/public-key/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'public_key': key_2}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    key2 = session.query(PublicKey).filter_by(public_key=key_2).scalar()
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    assert key.tags() == [], "No public keys should have a tag unless it's been added to the key"
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "dont_tag_me_bro", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag2 = PublicKeyTag.get(session, name="dont_tag_me_bro")
+
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    assert key.tags() == [], "No public keys should have a tag unless it's been added to the key"
+
+    fe_url = url(base_url, '/users/{}/public-key/{}/tag'.format(user.username, key.id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here"}),
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    assert len(key.tags()) == 1, "The key should have exactly 1 tag"
+    assert key.tags()[0].name == "tyler_was_here"
+
+    key2 = session.query(PublicKey).filter_by(public_key=key_2).scalar()
+    assert len(key2.tags()) == 0, "Keys other than the one with the added tag should not gain tags"
+
+    fe_url = url(base_url, '/users/{}/public-key/{}/tag'.format(user.username, key2.id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here"}),
+            headers={'X-Grouper-User': user.username})
+
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    # Remove tag
+    tag = PublicKeyTag.get(session, name="dont_tag_me_bro")
+    fe_url = url(base_url, '/users/{}/public-key/{}/delete_tag/{}'.format(user.username, key.id, tag.id))
+    with pytest.raises(HTTPError):
+        resp = yield http_client.fetch(fe_url, method="POST",
+                body="",
+                headers={'X-Grouper-User': "oliver@a.co"})
+
+    # Remove tag
+    tag = PublicKeyTag.get(session, name="dont_tag_me_bro")
+    fe_url = url(base_url, '/users/{}/public-key/{}/delete_tag/{}'.format(user.username, key.id, tag.id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body="",
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+
+    # Remove tag
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+    fe_url = url(base_url, '/users/{}/public-key/{}/delete_tag/{}'.format(user.username, key.id, tag.id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body="",
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+
+    key = session.query(PublicKey).filter_by(public_key=key_1).scalar()
+    assert len(key.tags()) == 0, "The key should have exactly 0 tags"
+
+    key2 = session.query(PublicKey).filter_by(public_key=key_2).scalar()
+    assert len(key2.tags()) == 1, "Removing a tag from one key should not affect other keys"
+
+@pytest.mark.gen_test
+def test_grant_permission_to_tag(users, http_client, base_url, session):
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
+    perm.add(session)
+    session.commit()
+
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    fe_url = url(base_url, '/permissions/grant_tag/{}'.format(tag.name))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'permission': TAG_EDIT, "argument": "*"}),
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+    perm = Permission.get(session, TAG_EDIT)
+    assert len(tag.my_permissions()) == 1, "The tag should have exactly 1 permission"
+    assert tag.my_permissions()[0].name == perm.name, "The tag's permission should be the one we added"
+    assert tag.my_permissions()[0].argument == "*", "The tag's permission should be the one we added"
+
+    # Make sure trying to add a permission to a tag doesn't fail horribly if it's already there
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    fe_url = url(base_url, '/permissions/grant_tag/{}'.format(tag.name))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'permission': TAG_EDIT, "argument": "*"}),
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+
+
+
+@pytest.mark.gen_test
+def test_edit_tag(users, http_client, base_url, session):
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
+    perm.add(session)
+    session.commit()
+
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    assert tag.description == "Test Tag Please Ignore", "The description should match what we created it with"
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+    fe_url = url(base_url, '/tags/{}/edit'.format(tag.id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({"description": "Don't tag me bro"}),
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    assert tag.description == "Don't tag me bro", "The description should have been updated"
+
+
+@pytest.mark.gen_test
+def test_permissions(users, http_client, base_url, session):
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
+    perm.add(session)
+    session.commit()
+
+    perm = Permission(name="it.literally.does.not.matter", description="Why is this not nullable?")
+    perm.add(session)
+    session.commit()
+
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name="it.literally.does.not.matter").scalar(), "*")
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    fe_url = url(base_url, '/permissions/grant_tag/{}'.format(tag.name))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'permission': TAG_EDIT, "argument": "prod"}),
+            headers={'X-Grouper-User': user.username})
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+    # add SSH key
+    fe_url = url(base_url, '/users/{}/public-key/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'public_key': key_1}),
+            headers={'X-Grouper-User': user.username})
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    fe_url = url(base_url, '/users/{}/public-key/{}/tag'.format(user.username, key.id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here"}),
+            headers={'X-Grouper-User': user.username})
+    
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+    assert len(key.my_permissions()) == 1, "The SSH Key should have only 1 permission"
+    assert key.my_permissions()[0].name == TAG_EDIT, "The SSH key's permission should be TAG_EDIT"
+    assert key.my_permissions()[0].argument == "prod", "The SSH key's permission argument should be restricted to the tag's argument"
+    assert len(user.my_permissions()) > 1, "The user should have more than 1 permission"
+
+def test_permission_intersection(standard_graph, session, users, groups, permissions):
+    p = namedtuple("Permission", ["name", "argument"])
+    astar = p("a", "*")
+    ar = p("a", "r")
+    at = p("a", "t")
+    bstar = p("b", "*")
+    br = p("b", "r")
+    cstar = p("c", "*")
+    cr = p("c", "r")
+
+    assert _permission_intersection([astar], [astar]) == set([astar]), "The intersection of two identical lists should be the set of the contents of the list"
+    assert _permission_intersection([ar], [ar]) == set([ar]), "The intersection of two identical lists should be the set of the contents of the list"
+    assert _permission_intersection([astar], [ar]) == set([ar]), "The intersection of perm, * with perm, blah should be perm, blah"
+    assert _permission_intersection([ar], [astar]) == set([ar]), "The intersection of perm, blah with perm, * should be perm, blah"
+
+    assert _permission_intersection([astar], [bstar]) == set(), "The intersection of two disjoint lists should be the empty set"
+    assert _permission_intersection([ar], [br]) == set(), "The intersection of two disjoint lists should be the empty set"
+    assert _permission_intersection([ar], [at]) == set(), "The intersection of two disjoint lists should be the empty set"
+
+    assert _permission_intersection([astar], [ar, at]) == set([ar, at]), "Wildcards should result in all applicable permissions being in the result"
+    assert _permission_intersection([astar, ar, br, cr], [at, bstar, cr]) == set([at, br, cr]), "This should work"
+
+@pytest.mark.gen_test
+def test_revoke_permission_from_tag(users, http_client, base_url, session):
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
+    perm.add(session)
+    session.commit()
+
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
+
+    fe_url = url(base_url, '/tags')
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'tagname': "tyler_was_here", "description": "Test Tag Please Ignore"}),
+            headers={'X-Grouper-User': user.username})
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    fe_url = url(base_url, '/permissions/grant_tag/{}'.format(tag.name))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'permission': TAG_EDIT, "argument": "*"}),
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+    perm = Permission.get(session, TAG_EDIT)
+    assert len(tag.my_permissions()) == 1, "The tag should have exactly 1 permission"
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    mapping = tag.my_permissions()[0]
+    fe_url = url(base_url, '/permissions/{}/revoke_tag/{}'.format(TAG_EDIT, mapping.mapping_id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body="",
+            headers={'X-Grouper-User': user.username})
+
+    assert resp.code == 200
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+    assert len(tag.my_permissions()) == 0, "The tag should have no permissions"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -7,10 +7,11 @@ from tornado.httpclient import HTTPError
 from fixtures import fe_app as app
 from fixtures import standard_graph, users, graph, groups, session, permissions  # noqa
 from grouper.model_soup import Group, User
-from grouper.models.public_key import PublicKey, _permission_intersection
+from grouper.models.public_key import PublicKey
 from grouper.models.public_key_tag import PublicKeyTag
 from grouper.models.permission import Permission
 from grouper.constants import TAG_EDIT
+from grouper.permissions import permission_intersection
 from url_util import url
 from util import get_users, get_groups, add_member, grant_permission
 from collections import namedtuple
@@ -336,17 +337,17 @@ def test_permission_intersection(standard_graph, session, users, groups, permiss
     cstar = p("c", "*")
     cr = p("c", "r")
 
-    assert _permission_intersection([astar], [astar]) == set([astar]), "The intersection of two identical lists should be the set of the contents of the list"
-    assert _permission_intersection([ar], [ar]) == set([ar]), "The intersection of two identical lists should be the set of the contents of the list"
-    assert _permission_intersection([astar], [ar]) == set([ar]), "The intersection of perm, * with perm, blah should be perm, blah"
-    assert _permission_intersection([ar], [astar]) == set([ar]), "The intersection of perm, blah with perm, * should be perm, blah"
+    assert permission_intersection([astar], [astar]) == set([astar]), "The intersection of two identical lists should be the set of the contents of the list"
+    assert permission_intersection([ar], [ar]) == set([ar]), "The intersection of two identical lists should be the set of the contents of the list"
+    assert permission_intersection([astar], [ar]) == set([ar]), "The intersection of perm, * with perm, blah should be perm, blah"
+    assert permission_intersection([ar], [astar]) == set([ar]), "The intersection of perm, blah with perm, * should be perm, blah"
 
-    assert _permission_intersection([astar], [bstar]) == set(), "The intersection of two disjoint lists should be the empty set"
-    assert _permission_intersection([ar], [br]) == set(), "The intersection of two disjoint lists should be the empty set"
-    assert _permission_intersection([ar], [at]) == set(), "The intersection of two disjoint lists should be the empty set"
+    assert permission_intersection([astar], [bstar]) == set(), "The intersection of two disjoint lists should be the empty set"
+    assert permission_intersection([ar], [br]) == set(), "The intersection of two disjoint lists should be the empty set"
+    assert permission_intersection([ar], [at]) == set(), "The intersection of two disjoint lists should be the empty set"
 
-    assert _permission_intersection([astar], [ar, at]) == set([ar, at]), "Wildcards should result in all applicable permissions being in the result"
-    assert _permission_intersection([astar, ar, br, cr], [at, bstar, cr]) == set([at, br, cr]), "This should work"
+    assert permission_intersection([astar], [ar, at]) == set([ar, at]), "Wildcards should result in all applicable permissions being in the result"
+    assert permission_intersection([astar, ar, br, cr], [at, bstar, cr]) == set([at, br, cr]), "This should work"
 
 @pytest.mark.gen_test
 def test_revoke_permission_from_tag(users, http_client, base_url, session):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -13,6 +13,7 @@ from grouper.models.permission import Permission
 from grouper.constants import TAG_EDIT
 from grouper.permissions import permission_intersection
 from grouper.public_key import get_public_key_permissions, get_public_key_tags, get_public_key_tag_permissions
+from grouper.user_permissions import user_permissions
 from url_util import url
 from util import get_users, get_groups, add_member, grant_permission
 from collections import namedtuple
@@ -325,7 +326,7 @@ def test_permissions(users, http_client, base_url, session):
     assert len(get_public_key_permissions(session, key)) == 1, "The SSH Key should have only 1 permission"
     assert get_public_key_permissions(session, key)[0].name == TAG_EDIT, "The SSH key's permission should be TAG_EDIT"
     assert get_public_key_permissions(session, key)[0].argument == "prod", "The SSH key's permission argument should be restricted to the tag's argument"
-    assert len(user.my_permissions()) > 1, "The user should have more than 1 permission"
+    assert len(user_permissions(session, user)) > 1, "The user should have more than 1 permission"
 
 def test_permission_intersection(standard_graph, session, users, groups, permissions):
     p = namedtuple("Permission", ["name", "argument"])

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -1,0 +1,80 @@
+import json
+
+import pytest
+
+from fixtures import api_app as app  # noqa
+from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
+from grouper.constants import TAG_EDIT
+from grouper.model_soup import Group
+from grouper.models.permission import Permission
+from grouper.models.public_key import PublicKey
+from grouper.models.public_key_tag import PublicKeyTag
+from grouper.models.user import User
+from grouper.permissions import grant_permission_to_tag
+from grouper.public_key import add_public_key, add_tag_to_public_key, get_public_key_permissions
+from grouper.user_permissions import user_permissions
+from url_util import url
+from util import grant_permission
+
+
+key1 = ('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCUQeasspT/etEJR2WUoR+h2sMOQYbJgr0Q'
+        'E+J8p97gEhmz107KWZ+3mbOwyIFzfWBcJZCEg9wy5Paj+YxbGONqbpXAhPdVQ2TLgxr41bNXvbcR'
+        'AxZC+Q12UZywR4Klb2kungKz4qkcmSZzouaKK12UxzGB3xQ0N+3osKFj3xA1+B6HqrVreU19XdVo'
+        'AJh0xLZwhw17/NDM+dAcEdMZ9V89KyjwjraXtOVfFhQF0EDF0ame8d6UkayGrAiXC2He0P2Cja+J'
+        '371P27AlNLHFJij8WGxvcGGSeAxMLoVSDOOllLCYH5UieV8mNpX1kNe2LeA58ciZb0AXHaipSmCH'
+        'gh/ some-comment')
+
+
+@pytest.mark.gen_test
+def test_tags(session, users, http_client, base_url, graph):
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
+    perm.add(session)
+    session.commit()
+
+    perm2 = Permission(name="it.literally.does.not.matter", description="Why is this not nullable?")
+    perm2.add(session)
+    session.commit()
+
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name="it.literally.does.not.matter").scalar(), "*")
+
+    tag = PublicKeyTag(name="tyler_was_here")
+    tag.add(session)
+    session.commit()
+
+    tag = PublicKeyTag.get(session, name="tyler_was_here")
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    grant_permission_to_tag(session, tag.id, perm.id, "prod")
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    add_public_key(session, user, key1)
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    add_tag_to_public_key(session, key, tag)
+
+    user = session.query(User).filter_by(username="testuser@a.co").scalar()
+
+    key = session.query(PublicKey).filter_by(user_id=user.id).scalar()
+    assert len(get_public_key_permissions(session, key)) == 1, "The SSH Key should have only 1 permission"
+    assert get_public_key_permissions(session, key)[0].name == TAG_EDIT, "The SSH key's permission should be TAG_EDIT"
+    assert get_public_key_permissions(session, key)[0].argument == "prod", "The SSH key's permission argument should be restricted to the tag's argument"
+    assert len(user_permissions(session, user)) > 1, "The user should have more than 1 permission"
+
+    graph.update_from_db(session)
+
+    fe_url = url(base_url, '/users/{}'.format(user.username))
+    resp = yield http_client.fetch(fe_url)
+    assert resp.code == 200
+    body = json.loads(resp.body)
+    pub_key = body['data']['user']['public_keys'][0]
+    assert len(pub_key['tags']) == 1, "The public key should only have 1 tag"
+    assert pub_key['tags'][0] == 'tyler_was_here', "The public key should have the tag we gave it"
+    assert len(pub_key['permissions']) == 1, "The public key should only have 1 permission"
+    assert pub_key['permissions'][0] == [TAG_EDIT, "prod"], "The public key should only have permissions that are the intersection of the user's permissions and the tag's permissions"


### PR DESCRIPTION
Allows public keys to only have a subset of the permissions that the public key's owner has, in order to enable having separate public keys for different use cases (and therefore limit the danger of credential compromise)