### PR TITLE
Add support for storing password hashes for users.

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -3,14 +3,8 @@ import re
 
 import sshpubkey
 from wtforms import (
-        BooleanField,
-        HiddenField,
-        IntegerField,
-        PasswordField,
-        SelectField,
-        StringField,
-        TextAreaField,
-        validators,
+        BooleanField, HiddenField, IntegerField, PasswordField,
+        SelectField, StringField, TextAreaField, validators
         )
 from wtforms.validators import ValidationError
 from wtforms_tornado import Form

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -6,6 +6,7 @@ from wtforms import (
         BooleanField,
         HiddenField,
         IntegerField,
+        PasswordField,
         SelectField,
         StringField,
         TextAreaField,
@@ -322,3 +323,12 @@ class PublicKeyAddTagForm(Form):
     tagname = SelectField("Tag", [
         validators.DataRequired(),
     ], choices=[["", "(select one)"]], default="")
+
+
+class UserPasswordForm(Form):
+    name = StringField("Password name", [
+        validators.DataRequired(),
+    ])
+    password = PasswordField("Password", [
+        validators.DataRequired(),
+    ])

--- a/grouper/fe/handlers/user_password_add.py
+++ b/grouper/fe/handlers/user_password_add.py
@@ -1,0 +1,66 @@
+from grouper.constants import USER_ADMIN
+from grouper.email_util import send_email
+from grouper.fe.forms import UserPasswordForm
+from grouper.fe.settings import settings
+from grouper.fe.util import GrouperHandler
+from grouper.model_soup import User
+from grouper.models.audit_log import AuditLog
+from grouper.user_password import add_new_user_password, PasswordAlreadyExists
+
+
+class UserPasswordAdd(GrouperHandler):
+    def get(self, user_id=None, name=None):
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if user.name != self.current_user.name and not (
+                self.current_user.has_permission(USER_ADMIN) and user.role_user
+        ):
+            return self.forbidden()
+
+        self.render("user-password-add.html", form=UserPasswordForm(), user=user)
+
+    def post(self, user_id=None, name=None):
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if user.name != self.current_user.name and not (
+                self.current_user.has_permission(USER_ADMIN) and user.role_user
+        ):
+            return self.forbidden()
+
+        form = UserPasswordForm(self.request.arguments)
+        if not form.validate():
+            return self.render(
+                "user-password-add.html", form=form, user=user,
+                alerts=self.get_form_alerts(form.errors),
+            )
+
+        pass_name = form.data["name"]
+        password = form.data["password"]
+        try:
+            add_new_user_password(self.session, pass_name, password, user.id)
+        except PasswordAlreadyExists:
+            self.session.rollback()
+            form.name.errors.append(
+                "Name already in use."
+            )
+            return self.render(
+                "user-password-add.html", form=form, user=user,
+                alerts=self.get_form_alerts(form.errors),
+            )
+
+        AuditLog.log(self.session, self.current_user.id, 'add_password',
+                     'Added password: {}'.format(pass_name),
+                     on_user_id=user.id)
+
+        email_context = {
+                "actioner": self.current_user.name,
+                "changed_user": user.name,
+                "password": password,
+                }
+        send_email(self.session, [user.name], 'User password created', 'user_password_created',
+                settings, email_context)
+        return self.redirect("/users/{}?refresh=yes".format(user.name))

--- a/grouper/fe/handlers/user_password_delete.py
+++ b/grouper/fe/handlers/user_password_delete.py
@@ -1,0 +1,38 @@
+from grouper.fe.util import GrouperHandler
+from grouper.model_soup import User
+from grouper.models.audit_log import AuditLog
+from grouper.models.user_password import UserPassword
+from grouper.user_password import delete_user_password, PasswordDoesNotExist
+
+
+class UserPasswordDelete(GrouperHandler):
+    def get(self, user_id=None, name=None, pass_id=None):
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if (user.name != self.current_user.name) and not self.current_user.user_admin:
+            return self.forbidden()
+        password = UserPassword.get(self.session, user=user, id=pass_id)
+        return self.render("user-password-delete.html", user=user, password=password)
+
+    def post(self, user_id=None, name=None, pass_id=None):
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if (user.name != self.current_user.name) and not self.current_user.user_admin:
+            return self.forbidden()
+
+        password = UserPassword.get(self.session, user=user, id=pass_id)
+
+        try:
+            delete_user_password(self.session, password.name, user.id)
+        except PasswordDoesNotExist:
+            # if the password doesn't exist, we can pretend like it did and that we deleted it
+            return self.redirect("/users/{}?refresh=yes".format(user.id))
+        AuditLog.log(self.session, self.current_user.id, 'delete_password',
+                     'Deleted password: {}'.format(password.name),
+                     on_user_id=user.id)
+        self.session.commit()
+        return self.redirect("/users/{}?refresh=yes".format(user.id))

--- a/grouper/fe/handlers/user_view.py
+++ b/grouper/fe/handlers/user_view.py
@@ -10,6 +10,7 @@ from grouper.public_key import (get_public_key_permissions, get_public_key_tags,
     get_public_keys_of_user)
 from grouper.user import get_log_entries_by_user, user_open_audits, user_requests_aggregate
 from grouper.user_metadata import get_user_metadata_by_key
+from grouper.user_password import user_passwords
 from grouper.user_permissions import user_is_user_admin
 
 
@@ -52,6 +53,7 @@ class UserView(GrouperHandler):
         open_audits = user_open_audits(self.session, user)
         group_edge_list = group_biz.get_groups_by_user(self.session, user) if user.enabled else []
         groups = [{'name': g.name, 'type': 'Group', 'role': ge._role} for g, ge in group_edge_list]
+        passwords = user_passwords(self.session, user)
         public_keys = get_public_keys_of_user(self.session, user.id)
         for key in public_keys:
             key.tags = get_public_key_tags(self.session, key)
@@ -65,6 +67,7 @@ class UserView(GrouperHandler):
                     groups=groups,
                     public_keys=public_keys,
                     can_control=can_control,
+                    passwords=passwords,
                     permissions=permissions,
                     can_disable=can_disable,
                     can_enable=can_enable,

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -45,6 +45,8 @@ from grouper.fe.handlers.tag_view import TagView
 from grouper.fe.handlers.tags_view import TagsView
 from grouper.fe.handlers.user_disable import UserDisable
 from grouper.fe.handlers.user_enable import UserEnable
+from grouper.fe.handlers.user_password_add import UserPasswordAdd
+from grouper.fe.handlers.user_password_delete import UserPasswordDelete
 from grouper.fe.handlers.user_requests import UserRequests
 from grouper.fe.handlers.user_shell import UserShell
 from grouper.fe.handlers.user_token_add import UserTokenAdd
@@ -103,6 +105,8 @@ for regex in (r"(?P<user_id>[0-9]+)", USERNAME_VALIDATION):
         ),
         (r"/users/{}/tokens/add".format(regex), UserTokenAdd),
         (r"/users/{}/tokens/(?P<token_id>[0-9]+)/disable".format(regex), UserTokenDisable),
+        (r"/users/{}/passwords/add".format(regex), UserPasswordAdd),
+        (r"/users/{}/passwords/(?P<pass_id>[0-9]+)/delete".format(regex), UserPasswordDelete),
     ])
 
 for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):

--- a/grouper/fe/templates/email/user_password_created_html.tmpl
+++ b/grouper/fe/templates/email/user_password_created_html.tmpl
@@ -1,0 +1,14 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}User Password Created{% endblock %}
+
+{% block content %}
+
+<p>A password named "{{ password.name }} was created for <strong><a href="{{url}}/users/{{changed_user}}">{{ changed_user }}</a></strong>.</p>
+
+{% if changed_user != actioner %}
+    <p>This edit was made by
+    <a href="{{url}}/users/{{actioner}}">{{ actioner }}</a>.</p>
+{% endif %}
+
+{% endblock %}

--- a/grouper/fe/templates/email/user_password_created_text.tmpl
+++ b/grouper/fe/templates/email/user_password_created_text.tmpl
@@ -1,0 +1,14 @@
+{% extends "email/base_html.tmpl" %}
+
+{% block subject %}User tokens changed{% endblock %}
+
+{% block content %}
+
+User token {{ action }} for {{ changed_user }}.
+
+{% if changed_user != actioner %}
+    This edit was made by
+    {{ actioner }}.
+{% endif %}
+
+{% endblock %}

--- a/grouper/fe/templates/forms/user-password.html
+++ b/grouper/fe/templates/forms/user-password.html
@@ -1,0 +1,17 @@
+{% macro form_field(field, label_width, field_width) -%}
+    <div class="form-group {% if field.errors %}has-error{% endif %}">
+        <label for="{{field.label.field_id}}"
+               class="col-sm-{{label_width}} control-label">
+            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+        </label>
+        <div class="col-sm-{{field_width}}">
+            {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}
+
+
+{{ form_field(form.name, 3, 8, class_="form-control", rows=5) }}
+{{ form_field(form.password, 3, 8, class_="form-control") }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -476,7 +476,6 @@ enabled. Membership in this group is regularly reviewed.
     </div>
 {%- endmacro %}
 
-
 {% macro tag_permission_panel(max_height, mappings, tag, can_grant=None) -%}
     <div class="panel panel-default">
         <div class="panel-heading">
@@ -543,6 +542,54 @@ enabled. Membership in this group is regularly reviewed.
         </label>
         <div class="col-sm-{{field_width}}">
             {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}
+
+{% macro one_user_password_row(password, username, can_control) -%}
+    <td>{{ password.name }}</td>
+    <td>{{ password.created_at | long_ago_str }}</td>
+    <td>
+    {% if can_control %}
+        <a class="btn btn-default btn-xs pull-right"
+           href="/users/{{ username }}/passwords/{{ password.id }}/delete">
+            <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span>
+        </a>
+    {% endif %}
+    </td>
+{%- endmacro %}
+
+{% macro passwords_panel(max_height, user, passwords, can_control=False) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Passwords</h3>
+        </div>
+        <div class="table-responsive" style="max-height: {{max_height}}px; overflow-y: auto">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-md-2">Name</th>
+                        <th class="col-md-1">Age</th>
+                        <th class="col-md-1"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for password in passwords %}
+                {% if password.enabled %}
+                    <tr>
+                        {{ one_user_password_row(password, user.name, can_control) }}
+                    </tr>
+                {% endif %}
+                {% endfor %}
+                </tbody>
+            </table>
+            {% if can_control %}
+            <div class='panel-footer'>
+                <a class="btn btn-default btn-sm" href="/users/{{ user.name }}/passwords/add">
+                <span class="glyphicon glyphicon-plus"></span> Create Password
+                </a>
+            </div>
+            {% endif %}
         </div>
     </div>
 {%- endmacro %}

--- a/grouper/fe/templates/user-password-add.html
+++ b/grouper/fe/templates/user-password-add.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/users">Users</a>
+{% endblock %}
+
+{% block subheading %}
+    Add Password
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Add Password</h3>
+       </div>
+        <div class="panel-body">
+            <p>
+                User passwords are used by some other applications to verify your identity.
+            </p>
+            <p>
+                Providing a user password to an application will <strong>allow it to perform any action
+                as you</strong>, so they should only be provided with trusted applications. For
+                example, scripts you wrote yourself, or have been approved by your organization's
+                IT and security teams.
+            </p>
+            <form class="form-horizontal" role="form"
+                  method="post" action="/users/{{user.name}}/passwords/add">
+                {% include "forms/user-password.html" %}
+                <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Add Password</button>
+                    </div>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/user-password-delete.html
+++ b/grouper/fe/templates/user-password-delete.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/users">Users</a>
+{% endblock %}
+
+{% block subheading %}
+    Delete Password
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Delete Password</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/users/{{user.name}}/passwords/{{ password.id }}/delete">
+                <div class="form-group text-center">
+                    Delete password with name <strong>{{ password.name }}</strong>?
+                </div>
+                {{ xsrf_form() }}
+                <div class="form-group text-center">
+                    <button type="submit" class="btn btn-primary">Delete password</button>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import group_panel, permission_panel, log_entry_panel, tokens_panel, public_key_modal, shell_panel %}
+{% from 'macros/ui.html' import group_panel, permission_panel, log_entry_panel, tokens_panel, public_key_modal, shell_panel, passwords_panel %}
 
 {% macro one_public_key_row(key, username, can_control) -%}
     <td><span class="has-help" data-toggle="popover" data-content="{{ key.created_on|print_date }}">
@@ -192,6 +192,12 @@
         </div>
     </div>
 {% endif %}
+<div class="row">
+    <div class="col-md-12">
+        {{ passwords_panel(390, user, passwords, can_control) }}
+    </div>
+</div>
+
 <div class="row">
     <div class="col-md-12">
         {{ log_entry_panel(390, log_entries) }}

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -146,10 +146,8 @@ class GroupGraph(object):
         '''
 
         def user_indexify(data):
-            ret = {}
+            ret = defaultdict(list)
             for item in data:
-                if item.user_id not in ret:
-                    ret[item.user_id] = []
                 ret[item.user_id].append(item)
             return ret
 
@@ -167,7 +165,7 @@ class GroupGraph(object):
                 "passwords": [
                     {
                          "name": password.name,
-                         "hash": password.password,
+                         "hash": password.password_hash,
                          "salt": password.salt,
                          "func": "SHA512",
                     } for password in passwords.get(user.id, [])

--- a/grouper/models/user_password.py
+++ b/grouper/models/user_password.py
@@ -59,10 +59,17 @@ class UserPassword(Model):
     def password(self):
         return self._hashed_secret
 
+    @property
+    def password_hash(self):
+        return self.password
+
     @password.setter
     def password(self, new_password):
         self.salt = _make_salt()
         self._hashed_secret = hashlib.sha512(new_password + self.salt).hexdigest()
+
+    def set_password(self, new_password):
+        self.password = new_password
 
     def check_password(self, password_to_check):
         h = hashlib.sha512(password_to_check + self.salt).hexdigest()
@@ -71,7 +78,7 @@ class UserPassword(Model):
     def check_hash(self, hash_to_check):
         return self.enabled and hmac.compare_digest(
                 hash_to_check,
-                self.password.encode('utf-8'),
+                self.password_hash.encode('utf-8'),
         )
 
     @property

--- a/grouper/models/user_password.py
+++ b/grouper/models/user_password.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+import hashlib
+import hmac
+import os
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from grouper.models.base.model_base import Model
+
+
+def _make_salt():
+    return os.urandom(20).encode("hex")
+
+
+class UserPassword(Model):
+    """Simple password hashes stored to a user for use by thirdparty applications"""
+
+    __tablename__ = "user_passwords"
+
+    id = Column(Integer, primary_key=True)
+
+    user_id = Column(Integer, ForeignKey("users.id"))
+    name = Column(String(length=16), nullable=False)
+
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    disabled_at = Column(DateTime, default=None, nullable=True)
+
+    _hashed_secret = Column(Text, nullable=False)
+    salt = Column(String(length=128), nullable=False)
+
+    user = relationship("User")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "name"),
+    )
+
+    @staticmethod
+    def get(session, user, name=None, id=None):
+        """Retrieves a single UserPassword.
+
+        Args:
+            session (Session): Session object
+            user (User): Owner of the password
+            name (str): Name of the password
+            id (int): Primary key of the password
+
+        Returns:
+            UserPassword: UserPassword matching the specified constraints
+
+        """
+        assert name is None or id is None
+
+        if name is not None:
+            return session.query(UserPassword).filter_by(name=name, user=user).scalar()
+        return session.query(UserPassword).filter_by(id=id, user=user).scalar()
+
+    @property
+    def password(self):
+        return self._hashed_secret
+
+    @password.setter
+    def password(self, new_password):
+        self.salt = _make_salt()
+        self._hashed_secret = hashlib.sha512(new_password + self.salt).hexdigest()
+
+    def check_password(self, password_to_check):
+        h = hashlib.sha512(password_to_check + self.salt).hexdigest()
+        return self.check_hash(h)
+
+    def check_hash(self, hash_to_check):
+        return self.enabled and hmac.compare_digest(
+                hash_to_check,
+                self.password.encode('utf-8'),
+        )
+
+    @property
+    def enabled(self):
+        return self.disabled_at is None and self.user.enabled
+
+    def __str__(self):
+        return "/".join((
+                self.user.username if self.user is not None else "unspecified",
+                self.name if self.name is not None else "unspecified",
+        ))

--- a/grouper/user_password.py
+++ b/grouper/user_password.py
@@ -23,13 +23,13 @@ def add_new_user_password(session, password_name, password, user_id):
         user_id(int): the id of the user to add this password to
     """
     p = UserPassword(name=password_name, user_id=user_id)
-    p.password = password
+    p.set_password(password)
+    Counter.incr(session, "updates")
     p.add(session)
     try:
         session.commit()
     except IntegrityError:
         raise PasswordAlreadyExists()
-    Counter.incr(session, "updates")
 
 
 def delete_user_password(session, password_name, user_id):
@@ -45,8 +45,8 @@ def delete_user_password(session, password_name, user_id):
     if not p:
         raise PasswordDoesNotExist()
     p.delete(session)
-    session.commit()
     Counter.incr(session, "updates")
+    session.commit()
 
 
 def user_passwords(session, user):

--- a/grouper/user_password.py
+++ b/grouper/user_password.py
@@ -1,0 +1,60 @@
+from sqlalchemy.exc import IntegrityError
+
+from grouper.models.counter import Counter
+from grouper.models.user_password import UserPassword
+
+
+class PasswordAlreadyExists(Exception):
+    pass
+
+
+class PasswordDoesNotExist(Exception):
+    pass
+
+
+def add_new_user_password(session, password_name, password, user_id):
+    # type: Session, str, str, int -> None
+    """Add the new user password specified.
+
+    Args:
+        session(grouper.models.base.session.Session): database session
+        password_name(str): name of the password to be added
+        password(str): the (plaintext) password to be added
+        user_id(int): the id of the user to add this password to
+    """
+    p = UserPassword(name=password_name, user_id=user_id)
+    p.password = password
+    p.add(session)
+    try:
+        session.commit()
+    except IntegrityError:
+        raise PasswordAlreadyExists()
+    Counter.incr(session, "updates")
+
+
+def delete_user_password(session, password_name, user_id):
+    # type: Session, str, int -> None
+    """Delete the specified UserPassword.
+
+    Args:
+        session(grouper.models.base.session.Session): database session
+        password_name: the name of the password to delete
+        user_id: the user whose password is being deleted
+    """
+    p = session.query(UserPassword).filter_by(name=password_name, user_id=user_id).scalar()
+    if not p:
+        raise PasswordDoesNotExist()
+    p.delete(session)
+    session.commit()
+    Counter.incr(session, "updates")
+
+
+def user_passwords(session, user):
+    # type: (Session, User) -> List[UserPassword]
+    """For a given user, return all of its passwords
+
+    Args:
+        session(models.base.session.Session): database session
+        user(User): user in question
+    """
+    return session.query(UserPassword).filter_by(user_id=user.id).all()

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -9,40 +9,44 @@ from fixtures import fe_app as app  # noqa
 from grouper import public_key
 from grouper.model_soup import User, Request, AsyncNotification
 from grouper.models.user_password import UserPassword
-from grouper.user_password import add_new_user_password, delete_user_password, PasswordAlreadyExists
+from grouper.user_password import (add_new_user_password, delete_user_password,
+    PasswordAlreadyExists, user_passwords)
 from url_util import url
+
+
+TEST_PASSWORD = "test_password_please_ignore"
 
 
 def test_passwords(session, users):
     user = users['zorkian@a.co']
 
-    add_new_user_password(session, "test", "test_password_please_ignore", user.id)
-    assert len(user.my_passwords()) == 1, "The user should only have a single password"
-    password = user.my_passwords()[0]
+    add_new_user_password(session, "test", TEST_PASSWORD, user.id)
+    assert len(user_passwords(session, user)) == 1, "The user should only have a single password"
+    password = user_passwords(session, user)[0]
     assert password.name == "test", "The password should have the name we gave it"
-    assert password.password != "test_password_please_ignore", "The password should not be what is passed in"
-    assert password.check_password("test_password_please_ignore"), "The password should validate when given the same password"
+    assert password.password_hash != TEST_PASSWORD, "The password should not be what is passed in"
+    assert password.check_password(TEST_PASSWORD), "The password should validate when given the same password"
     assert not password.check_password("sadfjhsdf"), "Incorrect passwords should fail"
     
-    add_new_user_password(session, "test2", "test_password_please_ignore", user.id)
-    assert len(user.my_passwords()) == 2, "The user should have 2 passwords"
-    password2 = user.my_passwords()[1]
+    add_new_user_password(session, "test2", TEST_PASSWORD, user.id)
+    assert len(user_passwords(session, user)) == 2, "The user should have 2 passwords"
+    password2 = user_passwords(session, user)[1]
     assert password2.name == "test2", "The password should have the name we gave it"
-    assert password2.password != "test_password_please_ignore", "The password should not be what is passed in"
-    assert password2.check_password("test_password_please_ignore"), "The password should validate when given the same password"
+    assert password2.password_hash != TEST_PASSWORD, "The password should not be what is passed in"
+    assert password2.check_password(TEST_PASSWORD), "The password should validate when given the same password"
     assert not password2.check_password("sadfjhsdf"), "Incorrect passwords should fail"
 
     with pytest.raises(PasswordAlreadyExists):
-        add_new_user_password(session, "test", "test_password_please_ignore", user.id)
+        add_new_user_password(session, "test", TEST_PASSWORD, user.id)
 
     session.rollback()
 
     # Technically there's a very very very small O(1/2^160) chance that this will fail for a correct implementation
-    assert password.password != password2.password, "2 passwords that are identical should hash differently because of the salts"
+    assert password.password_hash != password2.password_hash, "2 passwords that are identical should hash differently because of the salts"
 
     delete_user_password(session, "test", user.id)
-    assert len(user.my_passwords()) == 1, "The user should only have a single password"
-    assert user.my_passwords()[0].name == "test2", "The password named test should have been deleted"
+    assert len(user_passwords(session, user)) == 1, "The user should only have a single password"
+    assert user_passwords(session, user)[0].name == "test2", "The password named test should have been deleted"
 
 @pytest.mark.gen_test
 def test_fe_password_add(session, users, http_client, base_url):
@@ -50,41 +54,41 @@ def test_fe_password_add(session, users, http_client, base_url):
 
     fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
     resp = yield http_client.fetch(fe_url, method="POST",
-            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            body=urlencode({'name': "test", "password": TEST_PASSWORD}),
             headers={'X-Grouper-User': user.username})
     assert resp.code == 200
 
     user = session.query(User).filter_by(name="zorkian@a.co").scalar()
-    assert len(user.my_passwords()) == 1, "The user should have a password now"
-    assert user.my_passwords()[0].name == "test", "The password should have the name given"
-    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+    assert len(user_passwords(session, user)) == 1, "The user should have a password now"
+    assert user_passwords(session, user)[0].name == "test", "The password should have the name given"
+    assert user_passwords(session, user)[0].password_hash != TEST_PASSWORD, "The password should not be available as plain text"
 
     with pytest.raises(HTTPError):
         fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
         resp = yield http_client.fetch(fe_url, method="POST",
-                body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+                body=urlencode({'name': "test", "password": TEST_PASSWORD}),
                 headers={'X-Grouper-User': "testuser@a.co"})
 
     fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
     resp = yield http_client.fetch(fe_url, method="POST",
-            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            body=urlencode({'name': "test", "password": TEST_PASSWORD}),
             headers={'X-Grouper-User': user.username})
     assert resp.code == 200
 
     user = session.query(User).filter_by(name="zorkian@a.co").scalar()
-    assert len(user.my_passwords()) == 1, "Adding a password with the same name should fail"
+    assert len(user_passwords(session, user)) == 1, "Adding a password with the same name should fail"
 
     user = session.query(User).filter_by(name="testuser@a.co").scalar()
     fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
     resp = yield http_client.fetch(fe_url, method="POST",
-            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            body=urlencode({'name': "test", "password": TEST_PASSWORD}),
             headers={'X-Grouper-User': user.username})
     assert resp.code == 200
 
     user = session.query(User).filter_by(name="testuser@a.co").scalar()
-    assert len(user.my_passwords()) == 1, "The user should have a password now (duplicate names are permitted for distinct users)"
-    assert user.my_passwords()[0].name == "test", "The password should have the name given"
-    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+    assert len(user_passwords(session, user)) == 1, "The user should have a password now (duplicate names are permitted for distinct users)"
+    assert user_passwords(session, user)[0].name == "test", "The password should have the name given"
+    assert user_passwords(session, user)[0].password_hash != TEST_PASSWORD, "The password should not be available as plain text"
 
 @pytest.mark.gen_test
 def test_fe_password_delete(session, users, http_client, base_url):
@@ -92,42 +96,43 @@ def test_fe_password_delete(session, users, http_client, base_url):
 
     fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
     resp = yield http_client.fetch(fe_url, method="POST",
-            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            body=urlencode({'name': "test", "password": TEST_PASSWORD}),
             headers={'X-Grouper-User': user.username})
     assert resp.code == 200
 
     user = session.query(User).filter_by(name="zorkian@a.co").scalar()
-    assert len(user.my_passwords()) == 1, "The user should have a password now"
-    assert user.my_passwords()[0].name == "test", "The password should have the name given"
-    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+    assert len(user_passwords(session, user)) == 1, "The user should have a password now"
+    assert user_passwords(session, user)[0].name == "test", "The password should have the name given"
+    assert user_passwords(session, user)[0].password_hash != TEST_PASSWORD, "The password should not be available as plain text"
 
     user = session.query(User).filter_by(name="testuser@a.co").scalar()
     fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
     resp = yield http_client.fetch(fe_url, method="POST",
-            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            body=urlencode({'name': "test", "password": TEST_PASSWORD}),
             headers={'X-Grouper-User': user.username})
     assert resp.code == 200
 
     user = session.query(User).filter_by(name="testuser@a.co").scalar()
-    assert len(user.my_passwords()) == 1, "The user should have a password now (duplicate names are permitted for distinct users)"
-    assert user.my_passwords()[0].name == "test", "The password should have the name given"
-    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+    assert len(user_passwords(session, user)) == 1, "The user should have a password now (duplicate names are permitted for distinct users)"
+    assert user_passwords(session, user)[0].name == "test", "The password should have the name given"
+    assert user_passwords(session, user)[0].password_hash != TEST_PASSWORD, "The password should not be available as plain text"
 
     with pytest.raises(HTTPError):
         user = session.query(User).filter_by(name="zorkian@a.co").scalar()
-        fe_url = url(base_url, '/users/{}/passwords/{}/delete'.format(user.username, user.my_passwords()[0].id))
+        fe_url = url(base_url, '/users/{}/passwords/{}/delete'.format(user.username, user_passwords(session, user)[0].id))
         resp = yield http_client.fetch(fe_url, method="POST",
                 body="",
                 headers={'X-Grouper-User': "testuser@a.co"})
 
     user = session.query(User).filter_by(name="zorkian@a.co").scalar()
-    fe_url = url(base_url, '/users/{}/passwords/{}/delete'.format(user.username, user.my_passwords()[0].id))
+    fe_url = url(base_url, '/users/{}/passwords/{}/delete'.format(user.username, user_passwords(session, user)[0].id))
     resp = yield http_client.fetch(fe_url, method="POST",
             body="",
             headers={'X-Grouper-User': user.username})
     assert resp.code == 200
 
     user = session.query(User).filter_by(name="zorkian@a.co").scalar()
-    assert len(user.my_passwords()) == 0, "The password should have been deleted"
+    assert len(user_passwords(session, user)) == 0, "The password should have been deleted"
     user = session.query(User).filter_by(name="testuser@a.co").scalar()
-    assert len(user.my_passwords()) == 1, "Other user's passwords should not have been deleted"
+    assert len(user_passwords(session, user)) == 1, "Other user's passwords should not have been deleted"
+

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -1,0 +1,133 @@
+import json
+from urllib import urlencode
+
+import pytest
+from tornado.httpclient import HTTPError
+
+from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
+from fixtures import fe_app as app  # noqa
+from grouper import public_key
+from grouper.model_soup import User, Request, AsyncNotification
+from grouper.models.user_password import UserPassword
+from grouper.user_password import add_new_user_password, delete_user_password, PasswordAlreadyExists
+from url_util import url
+
+
+def test_passwords(session, users):
+    user = users['zorkian@a.co']
+
+    add_new_user_password(session, "test", "test_password_please_ignore", user.id)
+    assert len(user.my_passwords()) == 1, "The user should only have a single password"
+    password = user.my_passwords()[0]
+    assert password.name == "test", "The password should have the name we gave it"
+    assert password.password != "test_password_please_ignore", "The password should not be what is passed in"
+    assert password.check_password("test_password_please_ignore"), "The password should validate when given the same password"
+    assert not password.check_password("sadfjhsdf"), "Incorrect passwords should fail"
+    
+    add_new_user_password(session, "test2", "test_password_please_ignore", user.id)
+    assert len(user.my_passwords()) == 2, "The user should have 2 passwords"
+    password2 = user.my_passwords()[1]
+    assert password2.name == "test2", "The password should have the name we gave it"
+    assert password2.password != "test_password_please_ignore", "The password should not be what is passed in"
+    assert password2.check_password("test_password_please_ignore"), "The password should validate when given the same password"
+    assert not password2.check_password("sadfjhsdf"), "Incorrect passwords should fail"
+
+    with pytest.raises(PasswordAlreadyExists):
+        add_new_user_password(session, "test", "test_password_please_ignore", user.id)
+
+    session.rollback()
+
+    # Technically there's a very very very small O(1/2^160) chance that this will fail for a correct implementation
+    assert password.password != password2.password, "2 passwords that are identical should hash differently because of the salts"
+
+    delete_user_password(session, "test", user.id)
+    assert len(user.my_passwords()) == 1, "The user should only have a single password"
+    assert user.my_passwords()[0].name == "test2", "The password named test should have been deleted"
+
+@pytest.mark.gen_test
+def test_fe_password_add(session, users, http_client, base_url):
+    user = users['zorkian@a.co']
+
+    fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = session.query(User).filter_by(name="zorkian@a.co").scalar()
+    assert len(user.my_passwords()) == 1, "The user should have a password now"
+    assert user.my_passwords()[0].name == "test", "The password should have the name given"
+    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+
+    with pytest.raises(HTTPError):
+        fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
+        resp = yield http_client.fetch(fe_url, method="POST",
+                body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+                headers={'X-Grouper-User': "testuser@a.co"})
+
+    fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = session.query(User).filter_by(name="zorkian@a.co").scalar()
+    assert len(user.my_passwords()) == 1, "Adding a password with the same name should fail"
+
+    user = session.query(User).filter_by(name="testuser@a.co").scalar()
+    fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = session.query(User).filter_by(name="testuser@a.co").scalar()
+    assert len(user.my_passwords()) == 1, "The user should have a password now (duplicate names are permitted for distinct users)"
+    assert user.my_passwords()[0].name == "test", "The password should have the name given"
+    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+
+@pytest.mark.gen_test
+def test_fe_password_delete(session, users, http_client, base_url):
+    user = users['zorkian@a.co']
+
+    fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = session.query(User).filter_by(name="zorkian@a.co").scalar()
+    assert len(user.my_passwords()) == 1, "The user should have a password now"
+    assert user.my_passwords()[0].name == "test", "The password should have the name given"
+    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+
+    user = session.query(User).filter_by(name="testuser@a.co").scalar()
+    fe_url = url(base_url, '/users/{}/passwords/add'.format(user.username))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body=urlencode({'name': "test", "password": "test_password_please_ignore"}),
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = session.query(User).filter_by(name="testuser@a.co").scalar()
+    assert len(user.my_passwords()) == 1, "The user should have a password now (duplicate names are permitted for distinct users)"
+    assert user.my_passwords()[0].name == "test", "The password should have the name given"
+    assert user.my_passwords()[0].password != "test_password_please_ignore", "The password should not be available as plain text"
+
+    with pytest.raises(HTTPError):
+        user = session.query(User).filter_by(name="zorkian@a.co").scalar()
+        fe_url = url(base_url, '/users/{}/passwords/{}/delete'.format(user.username, user.my_passwords()[0].id))
+        resp = yield http_client.fetch(fe_url, method="POST",
+                body="",
+                headers={'X-Grouper-User': "testuser@a.co"})
+
+    user = session.query(User).filter_by(name="zorkian@a.co").scalar()
+    fe_url = url(base_url, '/users/{}/passwords/{}/delete'.format(user.username, user.my_passwords()[0].id))
+    resp = yield http_client.fetch(fe_url, method="POST",
+            body="",
+            headers={'X-Grouper-User': user.username})
+    assert resp.code == 200
+
+    user = session.query(User).filter_by(name="zorkian@a.co").scalar()
+    assert len(user.my_passwords()) == 0, "The password should have been deleted"
+    user = session.query(User).filter_by(name="testuser@a.co").scalar()
+    assert len(user.my_passwords()) == 1, "Other user's passwords should not have been deleted"


### PR DESCRIPTION
Allows users to add named passwords to their accounts. The passwords
are hashed using SHA512, and salted using a unique 160-bit salt that
is randomly generated for each password. The hashes and their salts
are exposed in the users API endpoint, so high risk passwords should
not be stored in Grouper due to the lack of authentication on the
user endpoint.