### PR TITLE
Change import statement ordering to match the Google Python Style Guide

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -1,14 +1,13 @@
+from cStringIO import StringIO
 import csv
+from datetime import datetime
+import re
 import sys
 import traceback
 
-from cStringIO import StringIO
-from datetime import datetime
-
-import re
-import sshpubkey
 from expvar.stats import stats
-from tornado.web import RequestHandler, HTTPError
+import sshpubkey
+from tornado.web import HTTPError, RequestHandler
 
 from grouper.constants import TOKEN_FORMAT
 from grouper.model_soup import User

--- a/grouper/api/routes.py
+++ b/grouper/api/routes.py
@@ -1,4 +1,4 @@
-from .handlers import Users, UsersPublicKeys, Groups, Permissions, Stats, NotFound, TokenValidate
+from .handlers import Groups, NotFound, Permissions, Stats, TokenValidate, Users, UsersPublicKeys
 from ..constants import NAME_VALIDATION, PERMISSION_VALIDATION
 
 HANDLERS = [

--- a/grouper/background.py
+++ b/grouper/background.py
@@ -9,9 +9,9 @@ from sqlalchemy.exc import OperationalError
 
 from grouper.email_util import notify_edge_expiration, process_async_emails
 from grouper.model_soup import Group, GroupEdge
+from grouper.models.base.session import get_db_engine, Session
 from grouper.perf_profile import prune_old_traces
 from grouper.util import get_database_url
-from grouper.models.base.session import Session, get_db_engine
 
 
 class BackgroundThread(Thread):

--- a/grouper/ctl/group.py
+++ b/grouper/ctl/group.py
@@ -1,6 +1,6 @@
 import logging
 
-from grouper.ctl.util import ensure_valid_username, ensure_valid_groupname, make_session
+from grouper.ctl.util import ensure_valid_groupname, ensure_valid_username, make_session
 from grouper.model_soup import Group, User
 from grouper.models.audit_log import AuditLog
 

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -11,7 +11,7 @@ from grouper.ctl import (
         user,
         user_proxy,
         )
-from grouper.settings import settings, default_settings_path
+from grouper.settings import default_settings_path, settings
 from grouper.util import get_loglevel
 
 

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -8,12 +8,12 @@ from grouper.constants import (
         )
 from grouper.ctl.util import make_session
 from grouper.model_soup import Group
+from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine
+from grouper.models.permission import Permission
+from grouper.permissions import grant_permission
 from grouper.settings import settings
 from grouper.util import get_database_url
-from grouper.models.base.model_base import Model
-from grouper.permissions import grant_permission
-from grouper.models.permission import Permission
 
 
 def sync_db_command(args):

--- a/grouper/ctl/util.py
+++ b/grouper/ctl/util.py
@@ -3,9 +3,9 @@ import logging
 import re
 
 from grouper.constants import NAME_VALIDATION, USERNAME_VALIDATION
+from grouper.models.base.session import get_db_engine, Session
 from grouper.settings import settings
 from grouper.util import get_database_url
-from grouper.models.base.session import Session, get_db_engine
 
 
 def ensure_valid_username(f):

--- a/grouper/database.py
+++ b/grouper/database.py
@@ -5,8 +5,8 @@ from time import sleep
 from expvar.stats import stats
 from sqlalchemy.exc import OperationalError
 
+from grouper.models.base.session import get_db_engine, Session
 from grouper.util import get_database_url
-from grouper.models.base.session import Session, get_db_engine
 
 
 class DbRefreshThread(Thread):

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import re
-import sshpubkey
 
+import sshpubkey
 from wtforms import (
         BooleanField,
         HiddenField,

--- a/grouper/fe/handlers/audits_complete.py
+++ b/grouper/fe/handlers/audits_complete.py
@@ -2,8 +2,8 @@ from grouper.audit import get_audits
 from grouper.constants import PERMISSION_AUDITOR
 from grouper.email_util import cancel_async_emails
 from grouper.fe.util import GrouperHandler
-from grouper.model_soup import AUDIT_STATUS_CHOICES, Audit
-from grouper.models.audit_log import AuditLogCategory, AuditLog
+from grouper.model_soup import Audit, AUDIT_STATUS_CHOICES
+from grouper.models.audit_log import AuditLog, AuditLogCategory
 
 
 class AuditsComplete(GrouperHandler):

--- a/grouper/fe/handlers/audits_create.py
+++ b/grouper/fe/handlers/audits_create.py
@@ -1,12 +1,14 @@
 from datetime import datetime, timedelta
+
 from sqlalchemy.exc import IntegrityError
+
 from grouper.constants import AUDIT_MANAGER
-from grouper.email_util import send_email, send_async_email
+from grouper.email_util import send_async_email, send_email
 from grouper.fe.forms import AuditCreateForm
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
-from grouper.model_soup import Audit, AuditMember, GROUP_EDGE_ROLES, Group
-from grouper.models.audit_log import AuditLogCategory, AuditLog
+from grouper.model_soup import Audit, AuditMember, Group, GROUP_EDGE_ROLES
+from grouper.models.audit_log import AuditLog, AuditLogCategory
 
 
 class AuditsCreate(GrouperHandler):

--- a/grouper/fe/handlers/audits_view.py
+++ b/grouper/fe/handlers/audits_view.py
@@ -2,7 +2,7 @@ from grouper.audit import get_audits
 from grouper.constants import AUDIT_MANAGER, AUDIT_VIEWER
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Audit
-from grouper.models.audit_log import AuditLogCategory, AuditLog
+from grouper.models.audit_log import AuditLog, AuditLogCategory
 
 
 class AuditsView(GrouperHandler):

--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -1,5 +1,6 @@
-import operator
 from datetime import datetime
+import operator
+
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
 from grouper.fe.forms import GroupAddForm
@@ -7,8 +8,8 @@ from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.group import get_all_groups
 from grouper.model_soup import Group
-from grouper.user import get_all_enabled_users, get_user_or_group
 from grouper.models.audit_log import AuditLog
+from grouper.user import get_all_enabled_users, get_user_or_group
 
 
 class GroupAdd(GrouperHandler):

--- a/grouper/fe/handlers/group_edit.py
+++ b/grouper/fe/handlers/group_edit.py
@@ -1,9 +1,10 @@
 from sqlalchemy.exc import IntegrityError
+
 from grouper.fe.forms import GroupEditForm
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Group
-from grouper.models.counter import Counter
 from grouper.models.audit_log import AuditLog
+from grouper.models.counter import Counter
 
 
 class GroupEdit(GrouperHandler):

--- a/grouper/fe/handlers/group_edit_member.py
+++ b/grouper/fe/handlers/group_edit_member.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.fe.forms import GroupEditMemberForm
-from grouper.fe.util import GrouperHandler, Alert
+from grouper.fe.util import Alert, GrouperHandler
 from grouper.model_soup import Group, GroupEdge, OBJ_TYPES, User
 
 

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -1,15 +1,16 @@
 from datetime import datetime
+
 from grouper import group as group_biz
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
 from grouper.fe.forms import GroupJoinForm
 from grouper.fe.settings import settings
-from grouper.fe.util import GrouperHandler, Alert
+from grouper.fe.util import Alert, GrouperHandler
 from grouper.model_soup import (
         APPROVER_ROLE_INDICIES,
+        Group,
         GROUP_EDGE_ROLES,
         GROUP_JOIN_CHOICES,
-        Group,
         User,
         )
 from grouper.models.audit_log import AuditLog

--- a/grouper/fe/handlers/group_permission_request.py
+++ b/grouper/fe/handlers/group_permission_request.py
@@ -1,11 +1,12 @@
 import json
+
 from grouper import permissions
 from grouper.fe.forms import GroupPermissionRequestDropdownForm, GroupPermissionRequestTextForm
 from grouper.fe.settings import settings
-from grouper.fe.util import GrouperHandler, Alert
+from grouper.fe.util import Alert, GrouperHandler
 from grouper.model_soup import Group
-from grouper.permissions import get_grantable_permissions
 from grouper.models.permission import Permission
+from grouper.permissions import get_grantable_permissions
 
 
 class GroupPermissionRequest(GrouperHandler):

--- a/grouper/fe/handlers/group_remove.py
+++ b/grouper/fe/handlers/group_remove.py
@@ -1,8 +1,8 @@
 from grouper.fe.forms import GroupRemoveForm
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Group
-from grouper.user import get_user_or_group
 from grouper.models.audit_log import AuditLog
+from grouper.user import get_user_or_group
 
 
 class GroupRemove(GrouperHandler):

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -2,10 +2,10 @@ from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
 from grouper.fe.forms import GroupRequestModifyForm
 from grouper.fe.settings import settings
-from grouper.fe.util import GrouperHandler, Alert
+from grouper.fe.util import Alert, GrouperHandler
 from grouper.model_soup import Group, GroupEdge, Request
-from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 from grouper.models.audit_log import AuditLog
+from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 
 
 class GroupRequestUpdate(GrouperHandler):

--- a/grouper/fe/handlers/group_view.py
+++ b/grouper/fe/handlers/group_view.py
@@ -1,4 +1,4 @@
-from grouper.fe.util import GrouperHandler, Alert
+from grouper.fe.util import Alert, GrouperHandler
 from grouper.graph import NoSuchGroup
 from grouper.model_soup import (APPROVER_ROLE_INDICIES, AUDIT_STATUS_CHOICES,
         Group, OWNER_ROLE_INDICES)

--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -1,4 +1,5 @@
 from sqlalchemy.exc import IntegrityError
+
 from grouper.fe.forms import GroupCreateForm
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Group

--- a/grouper/fe/handlers/help.py
+++ b/grouper/fe/handlers/help.py
@@ -1,4 +1,4 @@
-from grouper.constants import PERMISSION_GRANT, PERMISSION_CREATE, PERMISSION_AUDITOR
+from grouper.constants import PERMISSION_AUDITOR, PERMISSION_CREATE, PERMISSION_GRANT
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.models.permission import Permission

--- a/grouper/fe/handlers/perf_profile.py
+++ b/grouper/fe/handlers/perf_profile.py
@@ -1,4 +1,5 @@
 from tornado.web import RequestHandler
+
 from grouper import perf_profile
 from grouper.models.base.session import Session
 

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -1,6 +1,6 @@
 from grouper.fe.util import GrouperHandler
-from grouper.permissions import get_groups_by_permission, get_log_entries_by_permission
 from grouper.models.permission import Permission
+from grouper.permissions import get_groups_by_permission, get_log_entries_by_permission
 
 
 class PermissionView(GrouperHandler):

--- a/grouper/fe/handlers/permissions_create.py
+++ b/grouper/fe/handlers/permissions_create.py
@@ -1,9 +1,10 @@
 from sqlalchemy.exc import IntegrityError
+
 from grouper.fe.forms import PermissionCreateForm
 from grouper.fe.util import GrouperHandler, test_reserved_names
-from grouper.util import matches_glob
 from grouper.models.audit_log import AuditLog
 from grouper.models.permission import Permission
+from grouper.util import matches_glob
 
 
 class PermissionsCreate(GrouperHandler):

--- a/grouper/fe/handlers/permissions_grant.py
+++ b/grouper/fe/handlers/permissions_grant.py
@@ -1,12 +1,13 @@
 from sqlalchemy.exc import IntegrityError
+
 from grouper.audit import assert_controllers_are_auditors, UserNotAuditor
 from grouper.fe.forms import PermissionGrantForm
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Group
-from grouper.util import matches_glob
 from grouper.models.audit_log import AuditLog
-from grouper.permissions import grant_permission
 from grouper.models.permission import Permission
+from grouper.permissions import grant_permission
+from grouper.util import matches_glob
 
 
 class PermissionsGrant(GrouperHandler):

--- a/grouper/fe/handlers/permissions_request_update.py
+++ b/grouper/fe/handlers/permissions_request_update.py
@@ -1,7 +1,7 @@
 from grouper import permissions
 from grouper.audit import UserNotAuditor
 from grouper.fe.forms import PermissionRequestUpdateForm
-from grouper.fe.util import GrouperHandler, Alert
+from grouper.fe.util import Alert, GrouperHandler
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 
 

--- a/grouper/fe/handlers/permissions_revoke.py
+++ b/grouper/fe/handlers/permissions_revoke.py
@@ -1,8 +1,8 @@
 from grouper.fe.util import GrouperHandler
-from grouper.util import matches_glob
 from grouper.models.audit_log import AuditLog
 from grouper.models.counter import Counter
 from grouper.models.permission_map import PermissionMap
+from grouper.util import matches_glob
 
 
 class PermissionsRevoke(GrouperHandler):

--- a/grouper/fe/handlers/search.py
+++ b/grouper/fe/handlers/search.py
@@ -1,5 +1,6 @@
 from sqlalchemy import union_all
 from sqlalchemy.sql import label, literal
+
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Group, User
 

--- a/grouper/fe/handlers/user_token_add.py
+++ b/grouper/fe/handlers/user_token_add.py
@@ -1,4 +1,5 @@
 from sqlalchemy.exc import IntegrityError
+
 from grouper.constants import USER_ADMIN
 from grouper.email_util import send_email
 from grouper.fe.forms import UserTokenForm

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -1,6 +1,6 @@
 from grouper.constants import (
-        NAME_VALIDATION,
         NAME2_VALIDATION,
+        NAME_VALIDATION,
         PERMISSION_VALIDATION,
         USERNAME_VALIDATION,
         )

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -17,8 +17,8 @@ from grouper.constants import AUDIT_SECURITY, RESERVED_NAMES, USERNAME_VALIDATIO
 from grouper.fe.settings import settings
 from grouper.graph import Graph
 from grouper.model_soup import User
+from grouper.models.base.session import get_db_engine, Session
 from grouper.util import get_database_url
-from grouper.models.base.session import Session, get_db_engine
 
 
 class Alert(object):

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -1,14 +1,14 @@
 from collections import defaultdict, namedtuple
 from datetime import datetime
-from networkx import DiGraph, single_source_shortest_path
-from threading import RLock
 import logging
+from threading import RLock
 
+from networkx import DiGraph, single_source_shortest_path
 from sqlalchemy import or_
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import label, literal
 
-from grouper.model_soup import GROUP_EDGE_ROLES, Group, GroupEdge, User
+from grouper.model_soup import Group, GROUP_EDGE_ROLES, GroupEdge, User
 from grouper.models.counter import Counter
 from grouper.models.permission import MappedPermission, Permission
 from grouper.models.permission_map import PermissionMap

--- a/grouper/model_soup.py
+++ b/grouper/model_soup.py
@@ -10,35 +10,34 @@ import json
 import logging
 import re
 
+from sqlalchemy import asc, desc, or_, union_all
 from sqlalchemy import (
-    Column, Integer, String, Text, Boolean,
-    ForeignKey, Enum, DateTime, SmallInteger, Index
+    Boolean, Column, DateTime, Enum, ForeignKey, Index,
+    Integer, SmallInteger, String, Text
 )
-from sqlalchemy import or_, union_all, asc, desc
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import label, literal
 
+from grouper.models.audit_log import AuditLog
+from grouper.models.base.constants import REQUEST_STATUS_CHOICES
+from grouper.models.base.model_base import Model
+from grouper.models.base.session import flush_transaction
+from grouper.models.comment import Comment
+from grouper.models.counter import Counter
+from grouper.models.permission import Permission
+from grouper.models.permission_map import PermissionMap
+from grouper.models.public_key import PublicKey
+from grouper.models.user_metadata import UserMetadata
+from grouper.models.user_token import UserToken
 from .constants import (
-    PERMISSION_GRANT, PERMISSION_CREATE, MAX_NAME_LENGTH,
-    PERMISSION_VALIDATION, ILLEGAL_NAME_CHARACTER, PERMISSION_ADMIN,
-    GROUP_ADMIN, USER_ADMIN
+    GROUP_ADMIN, ILLEGAL_NAME_CHARACTER, MAX_NAME_LENGTH, PERMISSION_ADMIN,
+    PERMISSION_CREATE, PERMISSION_GRANT, PERMISSION_VALIDATION, USER_ADMIN
 )
 from .email_util import send_async_email
 from .plugin import get_plugins
 from .settings import settings
-from grouper.models.base.constants import REQUEST_STATUS_CHOICES
-from grouper.models.base.model_base import Model
-from grouper.models.base.session import flush_transaction
-from grouper.models.counter import Counter
-from grouper.models.audit_log import AuditLog
-from grouper.models.comment import Comment
-from grouper.models.public_key import PublicKey
-from grouper.models.user_metadata import UserMetadata
-from grouper.models.user_token import UserToken
-from grouper.models.permission_map import PermissionMap
-from grouper.models.permission import Permission
 
 
 OBJ_TYPES_IDX = ("User", "Group", "Request", "RequestStatusChange", "PermissionRequestStatusChange")

--- a/grouper/models/audit_log.py
+++ b/grouper/models/audit_log.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-
 from enum import IntEnum
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime, or_, desc
+
+from sqlalchemy import Column, DateTime, desc, ForeignKey, Integer, or_, String, Text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import relationship
 

--- a/grouper/models/base/session.py
+++ b/grouper/models/base/session.py
@@ -1,7 +1,8 @@
-from sqlalchemy.orm import sessionmaker, Session as _Session
-from sqlalchemy import create_engine
 import functools
 import logging
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as _Session, sessionmaker
 
 
 def flush_transaction(method):

--- a/grouper/models/comment.py
+++ b/grouper/models/comment.py
@@ -1,7 +1,9 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, Text, ForeignKey, DateTime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
 from grouper.models.base.model_base import Model
 
 

--- a/grouper/models/counter.py
+++ b/grouper/models/counter.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, DateTime
+
+from sqlalchemy import Column, DateTime, Integer, String
+
 from grouper.models.base.model_base import Model
 
 

--- a/grouper/models/perf_profile.py
+++ b/grouper/models/perf_profile.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from sqlalchemy import Column, String, DateTime, Index, LargeBinary
+
+from sqlalchemy import Column, DateTime, Index, LargeBinary, String
+
 from grouper.models.base.model_base import Model
 
 

--- a/grouper/models/permission.py
+++ b/grouper/models/permission.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime, asc
+from sqlalchemy import asc, Boolean, Column, DateTime, Integer, String, Text
 
 from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.base.model_base import Model

--- a/grouper/models/permission_map.py
+++ b/grouper/models/permission_map.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, UniqueConstraint, ForeignKey, DateTime
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from grouper.constants import MAX_NAME_LENGTH

--- a/grouper/models/permission_request.py
+++ b/grouper/models/permission_request.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, String, ForeignKey, Enum, DateTime
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES

--- a/grouper/models/permission_request_status_change.py
+++ b/grouper/models/permission_request_status_change.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Column, Integer, ForeignKey, Enum, DateTime
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 from grouper.model_soup import CommentObjectMixin

--- a/grouper/models/public_key.py
+++ b/grouper/models/public_key.py
@@ -1,6 +1,8 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
+
 from grouper.models.base.model_base import Model
 
 

--- a/grouper/models/user_metadata.py
+++ b/grouper/models/user_metadata.py
@@ -1,6 +1,8 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, UniqueConstraint, ForeignKey, DateTime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
+
 from grouper.models.base.model_base import Model
 
 

--- a/grouper/models/user_token.py
+++ b/grouper/models/user_token.py
@@ -3,9 +3,10 @@ import hashlib
 import hmac
 import os
 
-from grouper.models.base.model_base import Model
-from sqlalchemy import Column, Integer, String, UniqueConstraint, ForeignKey, DateTime
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
+
+from grouper.models.base.model_base import Model
 
 
 def _make_secret():

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -1,10 +1,10 @@
-import os
 import logging
+import os
 import threading
 import time
-import yaml
 
 from expvar.stats import stats
+import yaml
 
 
 class Settings(object):

--- a/grouper/user.py
+++ b/grouper/user.py
@@ -1,4 +1,4 @@
-from grouper.model_soup import User, Group
+from grouper.model_soup import Group, User
 
 
 def get_user_or_group(session, name, user_or_group=None):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-tornado==0.4.4
 coverage==3.7.1
 mock==1.3.0
 flake8==2.5.0
+flake8-import-order==0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 100
 ignore = E123,E126,E128,E711,E712
+import-order-style = google
+application-import-names = grouper


### PR DESCRIPTION
Also adds flake8-import-ordering to requirements-dev.txt to prevent
imports from being improperly ordered in the future.