### PR TITLE
Catch the IntegrityError in grouper.permissions.grant_permission

### DIFF
--- a/grouper/fe/handlers/permissions_grant.py
+++ b/grouper/fe/handlers/permissions_grant.py
@@ -89,6 +89,7 @@ class PermissionsGrant(GrouperHandler):
         try:
             grant_permission(self.session, group.id, permission.id, argument=form.data["argument"])
         except IntegrityError:
+            self.session.rollback()
             form.argument.errors.append(
                 "Permission and Argument already mapped to this group."
             )


### PR DESCRIPTION
I opted to have this fail silently, because the end result is what the caller wanted anyways