### PR TITLE
workaround user -> user_token relationship dep

### DIFF
--- a/grouper/ctl/group.py
+++ b/grouper/ctl/group.py
@@ -3,6 +3,7 @@ import logging
 from grouper.ctl.util import ensure_valid_groupname, ensure_valid_username, make_session
 from grouper.model_soup import Group
 from grouper.models.audit_log import AuditLog
+from grouper.models.user_token import UserToken  # noqa: HAX(herb) workaround user -> user_token dep
 from grouper.models.user import User
 
 

--- a/grouper/ctl/user.py
+++ b/grouper/ctl/user.py
@@ -3,6 +3,7 @@ import logging
 from grouper import public_key
 from grouper.ctl.util import ensure_valid_username, make_session
 from grouper.models.audit_log import AuditLog
+from grouper.models.user_token import UserToken  # noqa: HAX(herb) workaround user -> user_token dep
 from grouper.models.user import User
 from grouper.user import disable_user, enable_user, get_all_users
 from grouper.user_metadata import set_user_metadata


### PR DESCRIPTION
there's a dependency on the `user_token` model from `user` model. it's lazy-loaded but only an issue with CTL. FE/API already manages to load `user_token` cause they actually use it.