### PR TITLE
watchdog to monitor health of background processes

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -18,6 +18,7 @@ from grouper.graph import GroupGraph
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import load_plugins
 from grouper.settings import default_settings_path
+from grouper.thread_watchdog import start_watchdog
 from grouper.util import get_loglevel, get_database_url
 
 
@@ -100,6 +101,12 @@ def main(argv):
     background = BackgroundThread(settings, sentry_client)
     background.daemon = True
     background.start()
+
+    threads = [
+            ('database/graph', refresher),
+            ('background', background),
+            ]
+    start_watchdog(threads, sentry_client, settings.watchdog_wake_frequency_ms)
 
     address = args.address or settings.address
     port = args.port or settings.port

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -18,8 +18,9 @@ from grouper.fe.template_util import get_template_env
 from grouper.graph import Graph
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import load_plugins
-from grouper.util import get_loglevel, get_database_url
 from grouper.settings import default_settings_path
+from grouper.thread_watchdog import start_watchdog
+from grouper.util import get_loglevel, get_database_url
 
 
 try:
@@ -109,6 +110,11 @@ def main(argv):
     refresher = DbRefreshThread(settings, graph, settings.refresh_interval, sentry_client)
     refresher.daemon = True
     refresher.start()
+
+    threads = [
+            ('database/graph', refresher),
+            ]
+    start_watchdog(threads, sentry_client, settings.watchdog_wake_frequency_ms)
 
     address = args.address or settings.address
     port = args.port or settings.port

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -121,6 +121,10 @@ fe:
     shell:
         - [/bin/false, Your administrator has not configured Grouper for shell management]
 
+    # Time in milliseconds to check health of background threads.
+    # Type: int
+    watchdog_wake_frequency_ms: 5000
+
 api:
     # The port to listen to requests on.
     # Type: int
@@ -148,3 +152,7 @@ api:
     # port if one is needed.
     # Type: str
     url: "http://127.0.0.1:8888"
+
+    # Time in milliseconds to check health of background threads.
+    # Type: int
+    watchdog_wake_frequency_ms: 5000

--- a/grouper/api/settings.py
+++ b/grouper/api/settings.py
@@ -7,4 +7,5 @@ settings = Settings.from_settings(base_settings, {
     "port": 8990,
     "refresh_interval": 60,
     "url": "http://127.0.0.1:8888",
+    "watchdog_wake_frequency_ms": 5000,
 })

--- a/grouper/database.py
+++ b/grouper/database.py
@@ -25,6 +25,8 @@ class DbRefreshThread(Thread):
     def run(self):
         while True:
             sleep(self.refresh_interval)
+            sleep(5)
+            break
 
             logging.debug("Updating Graph from Database.")
             try:

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -30,4 +30,5 @@ settings = FeSettings.from_settings(base_settings, {
     "timezone": FeSettings.default_timezone,
     "url": "http://127.0.0.1:8888",
     "user_auth_header": "X-Grouper-User",
+    "watchdog_wake_frequency_ms": 5000,
 })

--- a/grouper/thread_watchdog.py
+++ b/grouper/thread_watchdog.py
@@ -1,0 +1,35 @@
+import logging
+
+import tornado.ioloop
+
+
+def start_watchdog(name_thread_list, sentry_client, wake_frequency_ms):
+    # type: (List[Tuple[str, Thread]], AsyncSentryClient, int, IOLoop) -> None
+    """A IOLoop based watchdog for running threads. Should any one thread no
+    longer be running, the watchdog will exit the ioloop.
+
+    Args:
+        name_thread_list: list of 2-tuple (name, Thread)
+        sentry_client: sentry client, if available, to report failures
+        wake_frequency_ms: frequency, in milliseconds, the watchdog should wake
+                and check thread health
+    """
+    logging.info("thread watchdog initialization")
+
+    def watchdog():
+        logging.info("thread watchdog wake")
+        for thread_name, thread_handle in name_thread_list:
+            if not thread_handle.is_alive():
+                # log death
+                msg = "thread '{}' is dead. exiting.".format(thread_name)
+                logging.error(msg)
+                if sentry_client:
+                    sentry_client.captureMessage(msg)
+
+                # exit
+                tornado.ioloop.IOLoop.instance().stop()
+
+        logging.info("thread watchdog sleep")
+
+    doggie = tornado.ioloop.PeriodicCallback(watchdog, wake_frequency_ms)
+    doggie.start()

--- a/grouper/thread_watchdog.py
+++ b/grouper/thread_watchdog.py
@@ -4,7 +4,7 @@ import tornado.ioloop
 
 
 def start_watchdog(name_thread_list, sentry_client, wake_frequency_ms):
-    # type: (List[Tuple[str, Thread]], AsyncSentryClient, int, IOLoop) -> None
+    # type: (List[Tuple[str, Thread]], AsyncSentryClient, int) -> None
     """A IOLoop based watchdog for running threads. Should any one thread no
     longer be running, the watchdog will exit the ioloop.
 
@@ -17,19 +17,19 @@ def start_watchdog(name_thread_list, sentry_client, wake_frequency_ms):
     logging.info("thread watchdog initialization")
 
     def watchdog():
-        logging.info("thread watchdog wake")
+        logging.info("thread watchdog: wake")
         for thread_name, thread_handle in name_thread_list:
             if not thread_handle.is_alive():
                 # log death
-                msg = "thread '{}' is dead. exiting.".format(thread_name)
-                logging.error(msg)
+                msg = "thread watchdog: thread '{}' is dead. exiting.".format(thread_name)
+                logging.critical(msg)
                 if sentry_client:
                     sentry_client.captureMessage(msg)
 
                 # exit
                 tornado.ioloop.IOLoop.instance().stop()
 
-        logging.info("thread watchdog sleep")
+        logging.info("thread watchdog: sleep")
 
     doggie = tornado.ioloop.PeriodicCallback(watchdog, wake_frequency_ms)
     doggie.start()


### PR DESCRIPTION
ioloop watchdog. two things:
1. i haven't found a good way to 'unit' test this. there aren't many good primitives for `PeriodicCallback`'s without `patch` stuff in ioloop internals. help welcome.
2. a reasonable alternative is to move the threads to ioloop callbacks which has it's pro/con. this was the simpler, less invasive change but i'm open to be convinced otherwise.