### PR TITLE
Remove duplicate instances of form_field

### DIFF
--- a/grouper/fe/templates/forms/group-edit-member.html
+++ b/grouper/fe/templates/forms/group-edit-member.html
@@ -1,14 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.role, 3, 8, class_="form-control") }}
 {{ form_field(form.expiration, 3, 8, class_="form-control", placeholder="MM/DD/YYYY or leave empty") }}

--- a/grouper/fe/templates/forms/group-permission-request-text.html
+++ b/grouper/fe/templates/forms/group-permission-request-text.html
@@ -1,14 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group form-group-{{field.label.field_id}} {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(text_form.permission_name, 3, 8, class_="form-control input-permission_name") }}
 {{ form_field(text_form.argument, 3, 8, class_="form-control") }}

--- a/grouper/fe/templates/forms/group.html
+++ b/grouper/fe/templates/forms/group.html
@@ -1,15 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
-
+{% from 'macros/ui.html' import form_field -%}
 
 {% if form.creatorrole %}
     {{ form_field(form.creatorrole, 3, 6, class_="form-control") }}

--- a/grouper/fe/templates/forms/permission-grant.html
+++ b/grouper/fe/templates/forms/permission-grant.html
@@ -1,14 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.permission, 3, 8, class_="form-control") }}
 {{ form_field(form.argument, 3, 8, class_="form-control") }}

--- a/grouper/fe/templates/forms/permission.html
+++ b/grouper/fe/templates/forms/permission.html
@@ -1,15 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
-
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.name, 3, 8, class_="form-control") }}
 {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}

--- a/grouper/fe/templates/forms/public-key-add-tag.html
+++ b/grouper/fe/templates/forms/public-key-add-tag.html
@@ -1,14 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.tagname, 3, 8, class_="form-control") }}
 

--- a/grouper/fe/templates/forms/public-key.html
+++ b/grouper/fe/templates/forms/public-key.html
@@ -1,15 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
-
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.public_key, 3, 8, class_="form-control", rows=5) }}
 

--- a/grouper/fe/templates/forms/tag-edit.html
+++ b/grouper/fe/templates/forms/tag-edit.html
@@ -1,15 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
-
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
 {{ form_field(form.enabled, 3, 4, class_="form-control") }}

--- a/grouper/fe/templates/forms/tag.html
+++ b/grouper/fe/templates/forms/tag.html
@@ -1,15 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
-
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.tagname, 3, 8, class_="form-control") }}
 {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}

--- a/grouper/fe/templates/forms/user-shell.html
+++ b/grouper/fe/templates/forms/user-shell.html
@@ -1,14 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.shell, 3, 8, class_="form-control") }}
 

--- a/grouper/fe/templates/forms/user-token.html
+++ b/grouper/fe/templates/forms/user-token.html
@@ -1,15 +1,4 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
-
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.name, 3, 8, class_="form-control", rows=5) }}
 

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -513,3 +513,14 @@ enabled. Membership in this group is regularly reviewed.
     </div>
 {%- endmacro %}
 
+{% macro form_field(field, label_width, field_width) -%}
+    <div class="form-group {% if field.errors %}has-error{% endif %}">
+        <label for="{{field.label.field_id}}"
+               class="col-sm-{{label_width}} control-label">
+            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+        </label>
+        <div class="col-sm-{{field_width}}">
+            {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}


### PR DESCRIPTION
Removes the many duplicated instances of form_field in favor of a single
macro definition in macros/ui.html.