### PR TITLE
Fix Permissions API for when a permission and group have the same name

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -187,7 +187,6 @@ class Permissions(GraphHandler):
             details = self.graph.get_permission_details(name)
 
             out = {"permission": {"name": name}}
-            try_update(out["permission"], self.graph.permission_metadata.get(name, {}))
             try_update(out, details)
             return self.success(out)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -71,6 +71,7 @@ def standard_graph(session, graph, users, groups, permissions):
     add_member(groups["team-sre"], users["zay@a.co"])
     add_member(groups["team-sre"], users["zorkian@a.co"])
     grant_permission(groups["team-sre"], permissions["ssh"], argument="*")
+    grant_permission(groups["team-sre"], permissions["team-sre"], argument="*")
 
     add_member(groups["serving-team"], users["zorkian@a.co"], role="owner")
     add_member(groups["serving-team"], groups["team-sre"])
@@ -162,7 +163,7 @@ def permissions(session, users):
     permissions = {
         permission: Permission.get_or_create(
             session, name=permission, description="{} permission".format(permission))[0]
-        for permission in ("ssh", "sudo", "audited", AUDIT_MANAGER, PERMISSION_AUDITOR)
+        for permission in ("ssh", "sudo", "audited", AUDIT_MANAGER, PERMISSION_AUDITOR, "team-sre")
     }
 
     enable_permission_auditing(session, permissions["audited"].name, users['zorkian@a.co'].id)

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -7,6 +7,7 @@ import pytest
 from fixtures import api_app as app  # noqa
 from fixtures import standard_graph, graph, users, groups, session, permissions  # noqa
 from grouper.constants import USER_METADATA_SHELL_KEY
+from grouper.models.permission import Permission
 from grouper.models.user_token import UserToken
 from grouper.user_metadata import get_user_metadata_by_key, set_user_metadata
 from grouper.user_token import add_new_user_token, disable_user_token
@@ -130,7 +131,7 @@ def test_usertokens(users, session, http_client, base_url):
 
 
 @pytest.mark.gen_test
-def test_permissions(permissions, http_client, base_url):
+def test_permissions(permissions, http_client, base_url, session, graph):
     api_url = url(base_url, '/permissions')
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
@@ -138,6 +139,13 @@ def test_permissions(permissions, http_client, base_url):
     assert resp.code == 200
     assert body["status"] == "ok"
     assert sorted(body["data"]["permissions"]) == sorted(permissions)
+
+    api_url = url(base_url, '/permissions/{}'.format("team-sre"))
+    resp = yield http_client.fetch(api_url)
+    body = json.loads(resp.body)
+
+    assert resp.code == 200
+    assert body["status"] == "ok"
 
 
 @pytest.mark.gen_test

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -62,18 +62,18 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
 
     graph = standard_graph  # noqa
 
-    assert sorted(get_group_permissions(graph, "team-sre")) == ["audited:", "ssh:*", "sudo:shell"]
+    assert sorted(get_group_permissions(graph, "team-sre")) == ["audited:", "ssh:*", "sudo:shell", "team-sre:*"]
     assert sorted(get_group_permissions(graph, "tech-ops")) == [
         "audited:", "ssh:shell", "sudo:shell"]
     assert sorted(get_group_permissions(graph, "team-infra")) == ["sudo:shell"]
     assert sorted(get_group_permissions(graph, "all-teams")) == []
 
     assert sorted(get_user_permissions(graph, "gary@a.co")) == [
-        "audited:", "ssh:*", "ssh:shell", "sudo:shell"]
+        "audited:", "ssh:*", "ssh:shell", "sudo:shell", "team-sre:*"]
     assert sorted(get_user_permissions(graph, "zay@a.co")) == [
-        "audited:", "ssh:*", "ssh:shell", "sudo:shell"]
+        "audited:", "ssh:*", "ssh:shell", "sudo:shell", "team-sre:*"]
     assert sorted(get_user_permissions(graph, "zorkian@a.co")) == [
-        "audited:", AUDIT_MANAGER + ":", PERMISSION_AUDITOR + ":", "ssh:*", "sudo:shell"]
+        "audited:", AUDIT_MANAGER + ":", PERMISSION_AUDITOR + ":", "ssh:*", "sudo:shell", "team-sre:*"]
     assert sorted(get_user_permissions(graph, "testuser@a.co")) == []
     assert sorted(get_user_permissions(graph, "figurehead@a.co")) == [
         "sudo:shell"]


### PR DESCRIPTION
There was an errant call to graph.permission_metadata.get(permission.name),
which doesn't make sense because graph permission_metadata is keyed by group
names, and only contains information relating to the mapping of all permissions
to the specified group. Additionally, this call site was expecting to receive
a dictionary, but graph.permission_metadata returns a list (or None in the
case where the provided name is not in permission_metadata). Because most
permissions do not have an identically named group, this would always
return None, and then the default of an empty dict would be returned.