### PR TITLE
Improve the performance of graph.update_from_db

### DIFF
--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -16,7 +16,7 @@ from grouper.models.public_key import PublicKey
 from grouper.models.user import User
 from grouper.models.user_metadata import UserMetadata
 from grouper.models.user_password import UserPassword
-from grouper.public_key import get_public_key_permissions, get_public_key_tags
+from grouper.public_key import get_all_public_key_tags
 from grouper.service_account import is_service_account
 from grouper.util import singleton
 
@@ -157,6 +157,7 @@ class GroupGraph(object):
         passwords = user_indexify(session.query(UserPassword).all())
         public_keys = user_indexify(session.query(PublicKey).all())
         user_metadata = user_indexify(session.query(UserMetadata).all())
+        public_key_tags = get_all_public_key_tags(session)
 
         out = {}
         for user in users:
@@ -176,9 +177,7 @@ class GroupGraph(object):
                         "public_key": key.public_key,
                         "fingerprint": key.fingerprint,
                         "created_on": str(key.created_on),
-                        "tags": [tag.name for tag in get_public_key_tags(session, key)],
-                        "permissions": [(perm.name, perm.argument)
-                                        for perm in get_public_key_permissions(session, key)],
+                        "tags": [tag.name for tag in public_key_tags.get(key.id, [])],
                     } for key in public_keys.get(user.id, [])
                 ],
                 "metadata": [

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import label
 import sshpubkey
@@ -163,6 +165,22 @@ def remove_tag_from_public_key(session, public_key, tag):
     mapping.delete(session)
     Counter.incr(session, "updates")
     session.commit()
+
+
+def get_all_public_key_tags(session):
+    # type: (Session) -> Dict[int, List[PublicKeyTag]]
+    """Returns a dict with all tags that are assigned to each public key
+
+    Args:
+        session: database session
+
+    Returns:
+        A dictionary that has all PublicKeyTags assigned to any public key
+    """
+    ret = defaultdict(list)
+    for mapping in session.query(PublicKeyTagMap).all():
+        ret[mapping.key.id].append(mapping.tag)
+    return ret
 
 
 def get_public_key_tags(session, public_key):

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -76,5 +76,5 @@ def test_tags(session, users, http_client, base_url, graph):
     pub_key = body['data']['user']['public_keys'][0]
     assert len(pub_key['tags']) == 1, "The public key should only have 1 tag"
     assert pub_key['tags'][0] == 'tyler_was_here', "The public key should have the tag we gave it"
-    assert len(pub_key['permissions']) == 1, "The public key should only have 1 permission"
-    assert pub_key['permissions'][0] == [TAG_EDIT, "prod"], "The public key should only have permissions that are the intersection of the user's permissions and the tag's permissions"
+    #assert len(pub_key['permissions']) == 1, "The public key should only have 1 permission"
+    #assert pub_key['permissions'][0] == [TAG_EDIT, "prod"], "The public key should only have permissions that are the intersection of the user's permissions and the tag's permissions"


### PR DESCRIPTION
Add get_all_public_key_tags to prevent us from having to use a new
database session and query for each public key (which was having a
very adverse effect on performance in graph.udpate_from_db). This also
removes the permissions key from the users public key API info, as
generating the permissions of the public keys is very slow (due to
relying on user_permissions, which is itself rather slow). It's
removal is temporary, until we are able to devise a more performant
solution.