### PR TITLE
Change user passwords to use Unix crypt(3)

### DIFF
--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -169,7 +169,7 @@ class GroupGraph(object):
                          "name": password.name,
                          "hash": password.password_hash,
                          "salt": password.salt,
-                         "func": "SHA512",
+                         "func": "crypt(3)-$6$",
                     } for password in passwords.get(user.id, [])
                 ],
                 "public_keys": [

--- a/grouper/models/user_password.py
+++ b/grouper/models/user_password.py
@@ -1,5 +1,5 @@
+import crypt
 from datetime import datetime
-import hashlib
 import hmac
 import os
 
@@ -65,14 +65,15 @@ class UserPassword(Model):
 
     @password.setter
     def password(self, new_password):
-        self.salt = _make_salt()
-        self._hashed_secret = hashlib.sha512(new_password + self.salt).hexdigest()
+        # Unix SHA512 passwords have a salt that starts with $6$ to indicate SHA512
+        self.salt = "$6$" + _make_salt()
+        self._hashed_secret = crypt.crypt(new_password, self.salt)
 
     def set_password(self, new_password):
         self.password = new_password
 
     def check_password(self, password_to_check):
-        h = hashlib.sha512(password_to_check + self.salt).hexdigest()
+        h = crypt.crypt(password_to_check, self.salt)
         return self.check_hash(h)
 
     def check_hash(self, hash_to_check):

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -1,3 +1,4 @@
+import crypt
 import json
 import hashlib
 
@@ -208,9 +209,9 @@ def test_passwords_api(session, users, http_client, base_url, graph):
     assert body["checkpoint"] == c.count, "The API response is not up to date"
     assert body["data"]["user"]["passwords"] != [], "The user should not have an empty passwords field"
     assert body["data"]["user"]["passwords"][0]["name"] == "test", "The password should have the same name"
-    assert body["data"]["user"]["passwords"][0]["func"] == "SHA512", "This test does not support any hash functions other than SHA512"
-    assert body["data"]["user"]["passwords"][0]["hash"] == hashlib.sha512(TEST_PASSWORD + body["data"]["user"]["passwords"][0]["salt"]).hexdigest(), "The hash should be the same as hashing the password and the salt together using the hashing function"
-    assert body["data"]["user"]["passwords"][0]["hash"] != hashlib.sha512("hello" + body["data"]["user"]["passwords"][0]["salt"]).hexdigest(), "The hash should not be the same as hashing the wrong password and the salt together using the hashing function"
+    assert body["data"]["user"]["passwords"][0]["func"] == "crypt(3)-$6$", "This test does not support any hash functions other than crypt(3)-$6$"
+    assert body["data"]["user"]["passwords"][0]["hash"] == crypt.crypt(TEST_PASSWORD, body["data"]["user"]["passwords"][0]["salt"]), "The hash should be the same as hashing the password and the salt together using the hashing function"
+    assert body["data"]["user"]["passwords"][0]["hash"] != crypt.crypt("hello", body["data"]["user"]["passwords"][0]["salt"]), "The hash should not be the same as hashing the wrong password and the salt together using the hashing function"
 
     delete_user_password(session, "test", user.id)
     c = Counter.get(session, name="updates")


### PR DESCRIPTION
All the usecases we have for user passwords require the hash to be in
standard unix crypt(3) SHA512 ($6$) format, so we're changing that
to be the default (and as of now, only) format we use. This does not
change any existing stored hashes (which is actually intractable),
so any already existing passwords must be deleted.