### PR TITLE
Move template variable logic to separate function for certain views

### DIFF
--- a/grouper/fe/handlers/group_view.py
+++ b/grouper/fe/handlers/group_view.py
@@ -1,68 +1,10 @@
-from grouper.fe.util import Alert, GrouperHandler
-from grouper.graph import NoSuchGroup
-from grouper.model_soup import (APPROVER_ROLE_INDICIES, AUDIT_STATUS_CHOICES,
-        Group, OWNER_ROLE_INDICES)
-from grouper.permissions import get_owner_arg_list, get_pending_request_by_group
+from grouper.fe.handlers.template_variables import get_group_view_template_vars
+from grouper.fe.util import GrouperHandler
+from grouper.model_soup import Group
 from grouper.service_account import is_service_account
-from grouper.user import user_role, user_role_index
-from grouper.user_permissions import user_grantable_permissions
 
 
 class GroupView(GrouperHandler):
-
-    @staticmethod
-    def get_template_vars(session, actor, group, graph):
-        ret = {}
-        ret["grantable"] = user_grantable_permissions(session, actor)
-
-        try:
-            group_md = graph.get_group_details(group.name)
-        except NoSuchGroup:
-            # Very new group with no metadata yet, or it has been disabled and
-            # excluded from in-memory cache.
-            group_md = {}
-
-        ret["members"] = group.my_members()
-        ret["groups"] = group.my_groups()
-        ret["permissions"] = group_md.get('permissions', [])
-
-        ret["permission_requests_pending"] = []
-        for req in get_pending_request_by_group(session, group):
-            granters = []
-            for owner, argument in get_owner_arg_list(session, req.permission, req.argument):
-                granters.append(owner.name)
-            ret["permission_requests_pending"].append((req, granters))
-
-        ret["audited"] = group_md.get('audited', False)
-        ret["log_entries"] = group.my_log_entries()
-        ret["num_pending"] = group.my_requests("pending").count()
-        ret["current_user_role"] = {
-            'is_owner': user_role_index(actor, ret["members"]) in OWNER_ROLE_INDICES,
-            'is_approver': user_role_index(actor, ret["members"]) in APPROVER_ROLE_INDICIES,
-            'is_manager': user_role(actor, ret["members"]) == "manager",
-            'is_member': user_role(actor, ret["members"]) is not None,
-            'role': user_role(actor, ret["members"]),
-            }
-        ret["can_leave"] = (ret["current_user_role"]['is_member'] and not
-            ret["current_user_role"]['is_owner'])
-        ret["statuses"] = AUDIT_STATUS_CHOICES
-
-        # Add mapping_id to permissions structure
-        ret["my_permissions"] = group.my_permissions()
-        for perm_up in ret["permissions"]:
-            for perm_direct in ret["my_permissions"]:
-                if (perm_up['permission'] == perm_direct.name and
-                        perm_up['argument'] == perm_direct.argument):
-                    perm_up['mapping_id'] = perm_direct.mapping_id
-                    break
-
-        ret["alerts"] = []
-        ret["self_pending"] = group.my_requests("pending", user=actor).count()
-        if ret["self_pending"]:
-            ret["alerts"].append(Alert('info', 'You have a pending request to join this group.',
-                None))
-
-        return ret
 
     def get(self, group_id=None, name=None):
         self.handle_refresh()
@@ -75,5 +17,5 @@ class GroupView(GrouperHandler):
 
         self.render(
             "group.html", group=group,
-            **self.get_template_vars(self.session, self.current_user, group, self.graph)
+            **get_group_view_template_vars(self.session, self.current_user, group, self.graph)
         )

--- a/grouper/fe/handlers/group_view.py
+++ b/grouper/fe/handlers/group_view.py
@@ -9,6 +9,61 @@ from grouper.user_permissions import user_grantable_permissions
 
 
 class GroupView(GrouperHandler):
+
+    @staticmethod
+    def get_template_vars(session, actor, group, graph):
+        ret = {}
+        ret["grantable"] = user_grantable_permissions(session, actor)
+
+        try:
+            group_md = graph.get_group_details(group.name)
+        except NoSuchGroup:
+            # Very new group with no metadata yet, or it has been disabled and
+            # excluded from in-memory cache.
+            group_md = {}
+
+        ret["members"] = group.my_members()
+        ret["groups"] = group.my_groups()
+        ret["permissions"] = group_md.get('permissions', [])
+
+        ret["permission_requests_pending"] = []
+        for req in get_pending_request_by_group(session, group):
+            granters = []
+            for owner, argument in get_owner_arg_list(session, req.permission, req.argument):
+                granters.append(owner.name)
+            ret["permission_requests_pending"].append((req, granters))
+
+        ret["audited"] = group_md.get('audited', False)
+        ret["log_entries"] = group.my_log_entries()
+        ret["num_pending"] = group.my_requests("pending").count()
+        ret["current_user_role"] = {
+            'is_owner': user_role_index(actor, ret["members"]) in OWNER_ROLE_INDICES,
+            'is_approver': user_role_index(actor, ret["members"]) in APPROVER_ROLE_INDICIES,
+            'is_manager': user_role(actor, ret["members"]) == "manager",
+            'is_member': user_role(actor, ret["members"]) is not None,
+            'role': user_role(actor, ret["members"]),
+            }
+        ret["can_leave"] = (ret["current_user_role"]['is_member'] and not
+            ret["current_user_role"]['is_owner'])
+        ret["statuses"] = AUDIT_STATUS_CHOICES
+
+        # Add mapping_id to permissions structure
+        ret["my_permissions"] = group.my_permissions()
+        for perm_up in ret["permissions"]:
+            for perm_direct in ret["my_permissions"]:
+                if (perm_up['permission'] == perm_direct.name and
+                        perm_up['argument'] == perm_direct.argument):
+                    perm_up['mapping_id'] = perm_direct.mapping_id
+                    break
+
+        ret["alerts"] = []
+        ret["self_pending"] = group.my_requests("pending", user=actor).count()
+        if ret["self_pending"]:
+            ret["alerts"].append(Alert('info', 'You have a pending request to join this group.',
+                None))
+
+        return ret
+
     def get(self, group_id=None, name=None):
         self.handle_refresh()
         group = Group.get(self.session, group_id, name)
@@ -18,56 +73,7 @@ class GroupView(GrouperHandler):
         if is_service_account(self.session, group=group):
             return self.redirect("/service/{}".format(group.groupname))
 
-        grantable = user_grantable_permissions(self.session, self.current_user)
-
-        try:
-            group_md = self.graph.get_group_details(group.name)
-        except NoSuchGroup:
-            # Very new group with no metadata yet, or it has been disabled and
-            # excluded from in-memory cache.
-            group_md = {}
-
-        members = group.my_members()
-        groups = group.my_groups()
-        permissions = group_md.get('permissions', [])
-
-        permission_requests_pending = []
-        for req in get_pending_request_by_group(self.session, group):
-            granters = []
-            for owner, argument in get_owner_arg_list(self.session, req.permission, req.argument):
-                granters.append(owner.name)
-            permission_requests_pending.append((req, granters))
-
-        audited = group_md.get('audited', False)
-        log_entries = group.my_log_entries()
-        num_pending = group.my_requests("pending").count()
-        current_user_role = {
-            'is_owner': user_role_index(self.current_user, members) in OWNER_ROLE_INDICES,
-            'is_approver': user_role_index(self.current_user, members) in APPROVER_ROLE_INDICIES,
-            'is_manager': user_role(self.current_user, members) == "manager",
-            'is_member': user_role(self.current_user, members) is not None,
-            'role': user_role(self.current_user, members),
-            }
-        can_leave = current_user_role['is_member'] and not current_user_role['is_owner']
-
-        # Add mapping_id to permissions structure
-        my_permissions = group.my_permissions()
-        for perm_up in permissions:
-            for perm_direct in my_permissions:
-                if (perm_up['permission'] == perm_direct.name and
-                        perm_up['argument'] == perm_direct.argument):
-                    perm_up['mapping_id'] = perm_direct.mapping_id
-                    break
-
-        alerts = []
-        self_pending = group.my_requests("pending", user=self.current_user).count()
-        if self_pending:
-            alerts.append(Alert('info', 'You have a pending request to join this group.', None))
-
         self.render(
-            "group.html", group=group, members=members, groups=groups,
-            num_pending=num_pending, alerts=alerts, permissions=permissions,
-            log_entries=log_entries, grantable=grantable, audited=audited,
-            statuses=AUDIT_STATUS_CHOICES, current_user_role=current_user_role,
-            permission_requests_pending=permission_requests_pending, can_leave=can_leave,
+            "group.html", group=group,
+            **self.get_template_vars(self.session, self.current_user, group, self.graph)
         )

--- a/grouper/fe/handlers/service_account_view.py
+++ b/grouper/fe/handlers/service_account_view.py
@@ -1,22 +1,10 @@
-from grouper.fe.handlers.group_view import GroupView
-from grouper.fe.handlers.user_view import UserView
+from grouper.fe.handlers.template_variables import get_service_account_view_template_vars
 from grouper.fe.util import GrouperHandler
 from grouper.model_soup import Group
 from grouper.models.user import User
-from grouper.service_account import can_manage_service_account
-from grouper.user import get_log_entries_by_user
 
 
 class ServiceAccountView(GrouperHandler):
-
-    @staticmethod
-    def get_template_vars(session, actor, user, group, graph):
-        ret = UserView.get_template_vars(session, actor, user, graph)
-        ret.update(GroupView.get_template_vars(session, actor, group, graph))
-        ret["can_control"] = can_manage_service_account(session, user=actor, tuser=user)
-        ret["log_entries"] = sorted(set(get_log_entries_by_user(session, user) +
-            group.my_log_entries()), key=lambda x: x.log_time, reverse=True)
-        return ret
 
     def get(self, user_id=None, name=None):
         self.handle_refresh()
@@ -27,8 +15,10 @@ class ServiceAccountView(GrouperHandler):
 
         group = Group.get(self.session, name=name)
         actor = self.current_user
+        graph = self.graph
+        session = self.session
         self.render("service.html",
                     user=user,
                     group=group,
-                    **self.get_template_vars(self.session, actor, user, group, self.graph)
+                    **get_service_account_view_template_vars(session, actor, user, group, graph)
                     )

--- a/grouper/fe/handlers/service_account_view.py
+++ b/grouper/fe/handlers/service_account_view.py
@@ -1,20 +1,23 @@
-from grouper.constants import USER_METADATA_SHELL_KEY
-from grouper.fe.handlers.user_disable import UserDisable
-from grouper.fe.handlers.user_enable import UserEnable
-from grouper.fe.util import Alert, GrouperHandler
-from grouper.graph import NoSuchGroup, NoSuchUser
-from grouper.model_soup import (APPROVER_ROLE_INDICIES, AUDIT_STATUS_CHOICES, Group,
-    OWNER_ROLE_INDICES, User)
-from grouper.permissions import get_owner_arg_list, get_pending_request_by_group
-from grouper.public_key import get_public_keys_of_user
+from grouper.fe.handlers.group_view import GroupView
+from grouper.fe.handlers.user_view import UserView
+from grouper.fe.util import GrouperHandler
+from grouper.model_soup import Group
+from grouper.models.user import User
 from grouper.service_account import can_manage_service_account
-from grouper.user import get_log_entries_by_user, user_role, user_role_index
-from grouper.user_group import get_groups_by_user
-from grouper.user_metadata import get_user_metadata_by_key
-from grouper.user_permissions import user_grantable_permissions
+from grouper.user import get_log_entries_by_user
 
 
 class ServiceAccountView(GrouperHandler):
+
+    @staticmethod
+    def get_template_vars(session, actor, user, group, graph):
+        ret = UserView.get_template_vars(session, actor, user, graph)
+        ret.update(GroupView.get_template_vars(session, actor, group, graph))
+        ret["can_control"] = can_manage_service_account(session, user=actor, tuser=user)
+        ret["log_entries"] = sorted(set(get_log_entries_by_user(session, user) +
+            group.my_log_entries()), key=lambda x: x.log_time, reverse=True)
+        return ret
+
     def get(self, user_id=None, name=None):
         self.handle_refresh()
         user = User.get(self.session, user_id, name)
@@ -22,88 +25,10 @@ class ServiceAccountView(GrouperHandler):
         if not user or not user.role_user:
             return self.notfound()
 
-        can_control = can_manage_service_account(self.session, user=self.current_user, tuser=user)
-        can_disable = UserDisable.check_access(self.session, self.current_user, user)
-        can_enable = UserEnable.check_access(self.session, self.current_user, user)
-
-        try:
-            user_md = self.graph.get_user_details(user.name)
-        except NoSuchUser:
-            # Either user is probably very new, so they have no metadata yet, or
-            # they're disabled, so we've excluded them from the in-memory graph.
-            user_md = {}
-
-        shell = (get_user_metadata_by_key(self.session, user.id, USER_METADATA_SHELL_KEY).data_value
-            if get_user_metadata_by_key(self.session, user.id, USER_METADATA_SHELL_KEY)
-            else "No shell configured")
         group = Group.get(self.session, name=name)
-
-        try:
-            group_md = self.graph.get_group_details(group.name)
-        except NoSuchGroup:
-            # Very new group with no metadata yet, or it has been disabled and
-            # excluded from in-memory cache.
-            group_md = {}
-
-        grantable = user_grantable_permissions(self.session, self.current_user)
-        members = group.my_members()
-        group_edge_list = get_groups_by_user(self.session, user) if user.enabled else []
-        groups = [{'name': g.name, 'type': 'Group', 'role': ge._role} for g, ge in group_edge_list]
-        public_keys = get_public_keys_of_user(self.session, user.id)
-        permissions = user_md.get('permissions', [])
-        # Combine the logs from the User and Group component. Use set to remove any duplicates
-        # and sorted to sort the combined logs by log time
-        log_entries = sorted(set(get_log_entries_by_user(self.session, user) +
-            group.my_log_entries()), key=lambda x: x.log_time, reverse=True)
-        current_user_role = {
-            'is_owner': user_role_index(self.current_user, members) in OWNER_ROLE_INDICES,
-            'is_approver': user_role_index(self.current_user, members) in APPROVER_ROLE_INDICIES,
-            'is_manager': user_role(self.current_user, members) == "manager",
-            'role': user_role(self.current_user, members),
-        }
-
-        permission_requests_pending = []
-        for req in get_pending_request_by_group(self.session, group):
-            granters = []
-            for owner, argument in get_owner_arg_list(self.session, req.permission, req.argument):
-                granters.append(owner.name)
-            permission_requests_pending.append((req, granters))
-
-        audited = group_md.get('audited', False)
-        num_pending = group.my_requests("pending").count()
-
-        # Add mapping_id to permissions structure
-        my_permissions = group.my_permissions()
-        for perm_up in permissions:
-            for perm_direct in my_permissions:
-                if (perm_up['permission'] == perm_direct.name and
-                        perm_up['argument'] == perm_direct.argument):
-                    perm_up['mapping_id'] = perm_direct.mapping_id
-                    break
-
-        alerts = []
-        self_pending = group.my_requests("pending", user=self.current_user).count()
-        if self_pending:
-            alerts.append(Alert('info', 'You have a pending request to join this group.', None))
-
+        actor = self.current_user
         self.render("service.html",
                     user=user,
                     group=group,
-                    members=members,
-                    groups=groups,
-                    public_keys=public_keys,
-                    can_control=can_control,
-                    permissions=permissions,
-                    can_disable=can_disable,
-                    can_enable=can_enable,
-                    user_tokens=user.tokens,
-                    log_entries=log_entries,
-                    shell=shell,
-                    current_user_role=current_user_role,
-                    num_pending=num_pending,
-                    alerts=alerts,
-                    grantable=grantable,
-                    audited=audited,
-                    statuses=AUDIT_STATUS_CHOICES,
-                    permission_requests_pending=permission_requests_pending,
+                    **self.get_template_vars(self.session, actor, user, group, self.graph)
                     )

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -1,0 +1,122 @@
+from grouper.constants import USER_METADATA_SHELL_KEY
+from grouper.fe.handlers.user_disable import UserDisable
+from grouper.fe.handlers.user_enable import UserEnable
+from grouper.fe.util import Alert
+from grouper.graph import NoSuchGroup, NoSuchUser
+from grouper.model_soup import APPROVER_ROLE_INDICIES, AUDIT_STATUS_CHOICES, OWNER_ROLE_INDICES
+from grouper.permissions import (get_owner_arg_list, get_pending_request_by_group,
+    get_requests_by_owner)
+from grouper.public_key import (get_public_key_permissions, get_public_key_tags,
+    get_public_keys_of_user)
+from grouper.service_account import can_manage_service_account
+from grouper.user import (get_log_entries_by_user, user_open_audits, user_requests_aggregate,
+    user_role, user_role_index)
+from grouper.user_group import get_groups_by_user
+from grouper.user_metadata import get_user_metadata_by_key
+from grouper.user_password import user_passwords
+from grouper.user_permissions import user_grantable_permissions, user_is_user_admin
+
+
+def get_group_view_template_vars(session, actor, group, graph):
+    ret = {}
+    ret["grantable"] = user_grantable_permissions(session, actor)
+
+    try:
+        group_md = graph.get_group_details(group.name)
+    except NoSuchGroup:
+        # Very new group with no metadata yet, or it has been disabled and
+        # excluded from in-memory cache.
+        group_md = {}
+
+    ret["members"] = group.my_members()
+    ret["groups"] = group.my_groups()
+    ret["permissions"] = group_md.get('permissions', [])
+
+    ret["permission_requests_pending"] = []
+    for req in get_pending_request_by_group(session, group):
+        granters = []
+        for owner, argument in get_owner_arg_list(session, req.permission, req.argument):
+            granters.append(owner.name)
+        ret["permission_requests_pending"].append((req, granters))
+
+    ret["audited"] = group_md.get('audited', False)
+    ret["log_entries"] = group.my_log_entries()
+    ret["num_pending"] = group.my_requests("pending").count()
+    ret["current_user_role"] = {
+        'is_owner': user_role_index(actor, ret["members"]) in OWNER_ROLE_INDICES,
+        'is_approver': user_role_index(actor, ret["members"]) in APPROVER_ROLE_INDICIES,
+        'is_manager': user_role(actor, ret["members"]) == "manager",
+        'is_member': user_role(actor, ret["members"]) is not None,
+        'role': user_role(actor, ret["members"]),
+        }
+    ret["can_leave"] = (ret["current_user_role"]['is_member'] and not
+        ret["current_user_role"]['is_owner'])
+    ret["statuses"] = AUDIT_STATUS_CHOICES
+
+    # Add mapping_id to permissions structure
+    ret["my_permissions"] = group.my_permissions()
+    for perm_up in ret["permissions"]:
+        for perm_direct in ret["my_permissions"]:
+            if (perm_up['permission'] == perm_direct.name and
+                    perm_up['argument'] == perm_direct.argument):
+                perm_up['mapping_id'] = perm_direct.mapping_id
+                break
+
+    ret["alerts"] = []
+    ret["self_pending"] = group.my_requests("pending", user=actor).count()
+    if ret["self_pending"]:
+        ret["alerts"].append(Alert('info', 'You have a pending request to join this group.',
+            None))
+
+    return ret
+
+
+def get_user_view_template_vars(session, actor, user, graph):
+    ret = {}
+    ret["can_control"] = (user.name == actor.name or user_is_user_admin(session, actor))
+    ret["can_disable"] = UserDisable.check_access(session, actor, user)
+    ret["can_enable"] = UserEnable.check_access(session, actor, user)
+
+    if user.id == actor.id:
+        ret["num_pending_group_requests"] = user_requests_aggregate(session, actor).count()
+        _, ret["num_pending_perm_requests"] = get_requests_by_owner(session, actor,
+            status='pending', limit=1, offset=0)
+    else:
+        ret["num_pending_group_requests"] = None
+        ret["num_pending_perm_requests"] = None
+
+    try:
+        user_md = graph.get_user_details(user.name)
+    except NoSuchUser:
+        # Either user is probably very new, so they have no metadata yet, or
+        # they're disabled, so we've excluded them from the in-memory graph.
+        user_md = {}
+
+    shell = (get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
+        if get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY)
+        else "No shell configured")
+    ret["shell"] = shell
+    ret["open_audits"] = user_open_audits(session, user)
+    group_edge_list = get_groups_by_user(session, user) if user.enabled else []
+    ret["groups"] = [{'name': g.name, 'type': 'Group', 'role': ge._role}
+        for g, ge in group_edge_list]
+    ret["passwords"] = user_passwords(session, user)
+    ret["public_keys"] = get_public_keys_of_user(session, user.id)
+    for key in ret["public_keys"]:
+        key.tags = get_public_key_tags(session, key)
+        key.pretty_permissions = ["{} ({})".format(perm.name,
+            perm.argument if perm.argument else "unargumented")
+            for perm in get_public_key_permissions(session, key)]
+    ret["permissions"] = user_md.get('permissions', [])
+    ret["log_entries"] = get_log_entries_by_user(session, user)
+
+    return ret
+
+
+def get_service_account_view_template_vars(session, actor, user, group, graph):
+    ret = get_user_view_template_vars(session, actor, user, graph)
+    ret.update(get_group_view_template_vars(session, actor, group, graph))
+    ret["can_control"] = can_manage_service_account(session, user=actor, tuser=user)
+    ret["log_entries"] = sorted(set(get_log_entries_by_user(session, user) +
+        group.my_log_entries()), key=lambda x: x.log_time, reverse=True)
+    return ret

--- a/grouper/fe/handlers/user_view.py
+++ b/grouper/fe/handlers/user_view.py
@@ -1,62 +1,9 @@
-from grouper.constants import USER_METADATA_SHELL_KEY
-from grouper.fe.handlers.user_disable import UserDisable
-from grouper.fe.handlers.user_enable import UserEnable
+from grouper.fe.handlers.template_variables import get_user_view_template_vars
 from grouper.fe.util import GrouperHandler
-from grouper.graph import NoSuchUser
 from grouper.models.user import User
-from grouper.permissions import get_requests_by_owner
-from grouper.public_key import (get_public_key_permissions, get_public_key_tags,
-    get_public_keys_of_user)
-from grouper.user import get_log_entries_by_user, user_open_audits, user_requests_aggregate
-from grouper.user_group import get_groups_by_user
-from grouper.user_metadata import get_user_metadata_by_key
-from grouper.user_password import user_passwords
-from grouper.user_permissions import user_is_user_admin
 
 
 class UserView(GrouperHandler):
-
-    @staticmethod
-    def get_template_vars(session, actor, user, graph):
-        ret = {}
-        ret["can_control"] = (user.name == actor.name or user_is_user_admin(session, actor))
-        ret["can_disable"] = UserDisable.check_access(session, actor, user)
-        ret["can_enable"] = UserEnable.check_access(session, actor, user)
-
-        if user.id == actor.id:
-            ret["num_pending_group_requests"] = user_requests_aggregate(session, actor).count()
-            _, ret["num_pending_perm_requests"] = get_requests_by_owner(session, actor,
-                 status='pending', limit=1, offset=0)
-        else:
-            ret["num_pending_group_requests"] = None
-            ret["num_pending_perm_requests"] = None
-
-        try:
-            user_md = graph.get_user_details(user.name)
-        except NoSuchUser:
-            # Either user is probably very new, so they have no metadata yet, or
-            # they're disabled, so we've excluded them from the in-memory graph.
-            user_md = {}
-
-        shell = (get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
-            if get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY)
-            else "No shell configured")
-        ret["shell"] = shell
-        ret["open_audits"] = user_open_audits(session, user)
-        group_edge_list = get_groups_by_user(session, user) if user.enabled else []
-        ret["groups"] = [{'name': g.name, 'type': 'Group', 'role': ge._role}
-            for g, ge in group_edge_list]
-        ret["passwords"] = user_passwords(session, user)
-        ret["public_keys"] = get_public_keys_of_user(session, user.id)
-        for key in ret["public_keys"]:
-            key.tags = get_public_key_tags(session, key)
-            key.pretty_permissions = ["{} ({})".format(perm.name,
-               perm.argument if perm.argument else "unargumented")
-               for perm in get_public_key_permissions(session, key)]
-        ret["permissions"] = user_md.get('permissions', [])
-        ret["log_entries"] = get_log_entries_by_user(session, user)
-
-        return ret
 
     def get(self, user_id=None, name=None):
         self.handle_refresh()
@@ -74,5 +21,5 @@ class UserView(GrouperHandler):
 
         self.render("user.html",
                     user=user,
-                    **self.get_template_vars(self.session, self.current_user, user, self.graph)
+                    **get_user_view_template_vars(self.session, self.current_user, user, self.graph)
                     )


### PR DESCRIPTION
Moved the code for retrieving and calculating the various template
variables used in UserView, GroupView, and ServiceAccountView to
separate functions on each class called get_template_vars. This
allows the template retrieval logic in ServiceAccountView to reuse
the code in UserView and GroupView, since ServiceAccountView is
essentially a combination of those two handlers.