### PR TITLE
Propagate refresh argument when we return redirects

### DIFF
--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -49,7 +49,7 @@ except ImportError:
 else:
     class SentryHandler(SentryMixin, RequestHandler):
         pass
-    RequestHandler = SentryHandler
+    RequestHandler = SentryHandler  # type: ignore # no support for conditional declarations #1152
 
 
 class GrouperHandler(RequestHandler):


### PR DESCRIPTION
This ensures that whatever the final respnse is, it will be based
on a fully refreshed graph. Failing to propagate the refresh could
lead to inconsistent views when using a simple loadbalancer which
directs the first request (with refresh=yes) to one server, and then
the resulting redirect request (with refresh=no) to a different
server, which has not refreshed the graph since the last change.