### PR TITLE
Allow group names to be up to 128 characters long

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -100,7 +100,7 @@ class GroupCreateForm(Form):
             ("owner", "Owner"), ("np-owner", "No-Permissions Owner"),
             ], default="owner")
     groupname = StringField("Name", [
-        validators.Length(min=3, max=32),
+        validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
         validators.DataRequired(),
         ValidateRegex(constants.NAME_VALIDATION),
     ])
@@ -112,7 +112,7 @@ class GroupCreateForm(Form):
 
 class GroupEditForm(Form):
     groupname = StringField("Name", [
-        validators.Length(min=3, max=32),
+        validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
         validators.DataRequired(),
         ValidateRegex(constants.NAME_VALIDATION),
     ])
@@ -332,7 +332,7 @@ class UserPasswordForm(Form):
 
 class ServiceAccountCreateForm(Form):
     name = StringField("Name", [
-        validators.Length(min=3, max=32),
+        validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
         validators.DataRequired(),
         ValidateRegex(constants.NAME_VALIDATION),
         ValidateRegex(constants.USERNAME_VALIDATION),

--- a/grouper/model_soup.py
+++ b/grouper/model_soup.py
@@ -88,7 +88,7 @@ class Group(Model, CommentObjectMixin):
     __tablename__ = "groups"
 
     id = Column(Integer, primary_key=True)
-    groupname = Column(String(length=32), unique=True, nullable=False)
+    groupname = Column(String(length=MAX_NAME_LENGTH), unique=True, nullable=False)
     description = Column(Text)
     canjoin = Column(Enum(*GROUP_JOIN_CHOICES), default="canask")
     enabled = Column(Boolean, default=True, nullable=False)


### PR DESCRIPTION
This brings group names up to par with most other first order
Grouper objects such as permissions and user names. This is
especially important because service account group names
must be identical to service account user names.