### PR TITLE
Unargumented Permissions are now handled properly for tagging

### DIFF
--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -646,16 +646,20 @@ def permission_intersection(perms_a, perms_b):
         if perm.argument in pdict_b[perm.name]:
             ret.add(perm)
             continue
+        # Unargumented permissions are granted by any permission with the same name
+        if perm.argument == "":
+            ret.add(perm)
+            continue
         # Argument wildcard
         if "*" in pdict_b[perm.name]:
             ret.add(perm)
             continue
-        # According to Group.has_permission, None as an argument counts as a wildcard too
-        if None in pdict_b[perm.name]:
-            ret.add(perm)
+        # Unargumented permissions are granted by any permission with the same name
+        if "" in pdict_b[perm.name]:
+            ret.add(pdict_b[perm.name][""])
             continue
         # If this permission is a wildcard, we add all permissions with the same name from
         # the other set
-        if perm.argument == "*" or perm.argument is None:
+        if perm.argument == "*":
             ret |= {p for p in pdict_b[perm.name].values()}
     return ret

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -333,6 +333,7 @@ def test_permission_intersection(standard_graph, session, users, groups, permiss
     astar = p("a", "*")
     ar = p("a", "r")
     at = p("a", "t")
+    aundef = p("a", "")
     bstar = p("b", "*")
     br = p("b", "r")
     cstar = p("c", "*")
@@ -348,6 +349,8 @@ def test_permission_intersection(standard_graph, session, users, groups, permiss
     assert permission_intersection([ar], [at]) == set(), "The intersection of two disjoint lists should be the empty set"
 
     assert permission_intersection([astar], [ar, at]) == set([ar, at]), "Wildcards should result in all applicable permissions being in the result"
+    assert permission_intersection([aundef], [ar, at]) == set([aundef]), "Unargumented permissions are always granted by argumented permissions"
+    assert permission_intersection([ar, at], [aundef]) == set([aundef]), "Unargumented permissions are always granted by argumented permissions"
     assert permission_intersection([astar, ar, br, cr], [at, bstar, cr]) == set([at, br, cr]), "This should work"
 
 @pytest.mark.gen_test


### PR DESCRIPTION
Due to a typo, unargumented permissions were treated identically to
argumented permissions (arguments was being checked against None as
opposed to the empty string). However, the previous code was incorrect
in assuming that an unargumented permission should be considered a
grant wildcard (same as *). Rather, unargumented permissions should
be receive wildcards, in that any permission with the same name,
regardless of argument, grants the unargumented form.