### PR TITLE
Fix bug when adding a group to a group

### DIFF
--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -80,7 +80,7 @@ class GroupAdd(GrouperHandler):
             )
 
         member = get_user_or_group(self.session, form.data["member"])
-        if is_service_account(self.session, member):
+        if member.type == "User" and is_service_account(self.session, member):
             # For service accounts, we want to always add the group to other groups, not the user
             member = get_service_account(self.session, user=member).group
         if not member:


### PR DESCRIPTION
I forgot to add a check to ensure the member being added
was a user before checking to see if it's a service account.
This adds that check.