### PR TITLE
initialize the server workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,2 @@
+load('/build_tools/bazel/workspace', 'server_deps')
+server_deps()


### PR DESCRIPTION
Declaring the server repo's dependencies is now required to use its build_tools.