### PR TITLE
Fix typo in tests.fixtures ASCII graph

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -66,7 +66,7 @@ def standard_graph(session, graph, users, groups, permissions):
     +-----------------------+
     |                       |
     |  user-admins          |
-    |    * tyleromeara(o)   |
+    |    * tyleromeara (o)  |
     |                       |
     +-----------------------+
 


### PR DESCRIPTION
All of the users that are owners have a space between the username
and the (o) in the ASCII graph. This adds that space for the only
instance where that was not the case.