### PR TITLE
Add length validator for password names

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -324,6 +324,7 @@ class PublicKeyAddTagForm(Form):
 class UserPasswordForm(Form):
     name = StringField("Password name", [
         validators.DataRequired(),
+        validators.Length(min=1, max=16),
     ])
     password = PasswordField("Password", [
         validators.DataRequired(),


### PR DESCRIPTION
The name of passwords is limited to 16 characters (unique keys don't
work for infinite length columns such as TEXT), but we weren't
restricting the length of the password in the UI. This lead to password
names getting truncated without the user being informed, leading to poor
user experience.