### PR TITLE
Add service_accounts API endpoint

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -246,7 +246,7 @@ class ServiceAccounts(GraphHandler):
 
         with self.graph.lock:
             return self.success({
-                "users": sorted([k
+                "service_accounts": sorted([k
                                 for k, v in self.graph.user_metadata.iteritems()
                                 if v["role_user"]]),
             })

--- a/grouper/api/routes.py
+++ b/grouper/api/routes.py
@@ -2,6 +2,7 @@ from grouper.api.handlers import (
         Groups,
         NotFound,
         Permissions,
+        ServiceAccounts,
         TokenValidate,
         Users,
         UsersPublicKeys,
@@ -23,6 +24,9 @@ HANDLERS = [
 
     (r"/permissions", Permissions),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), Permissions),
+
+    (r"/service_accounts", ServiceAccounts),
+    (r"/service_accounts/{}".format(NAME_VALIDATION), ServiceAccounts),
 
     (r"/debug/stats", Stats),
 

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -21,7 +21,6 @@ from util import grant_permission
 
 @pytest.mark.gen_test
 def test_users(users, http_client, base_url):
-    # without role users
     api_url = url(base_url, '/users')
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
@@ -33,17 +32,20 @@ def test_users(users, http_client, base_url):
     assert body["status"] == "ok"
     assert sorted(body["data"]["users"]) == users_wo_role
 
-    # with role users
-    api_url = url(base_url, '/users', {'include_role_users': 'yes'})
+    # TODO: test cutoff
+
+
+@pytest.mark.gen_test
+def test_service_accounts(users, http_client, base_url):
+    api_url = url(base_url, '/service_accounts')
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
-    users_w_role = sorted(users)
+    service_accounts = sorted([user.name for user in users.values() if user.role_user])
 
     assert resp.code == 200
     assert body["status"] == "ok"
-    assert sorted(body["data"]["users"]) == users_w_role
+    assert sorted(body["data"]["users"]) == service_accounts
 
-    # TODO: test cutoff
 
 @pytest.mark.gen_test
 def test_usertokens(users, session, http_client, base_url):

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -44,7 +44,7 @@ def test_service_accounts(users, http_client, base_url):
 
     assert resp.code == 200
     assert body["status"] == "ok"
-    assert sorted(body["data"]["users"]) == service_accounts
+    assert sorted(body["data"]["service_accounts"]) == service_accounts
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
This removes the ability to get information about service accounts from
the users endpoint and adds a new endpoint specifically for service
accounts. This was done to maintain a separation between the two due to
their often widely different uses and requirements.