### PR TITLE
PublicKeyAddTag now uses check_access

### DIFF
--- a/grouper/fe/handlers/public_key_add_tag.py
+++ b/grouper/fe/handlers/public_key_add_tag.py
@@ -4,15 +4,23 @@ from grouper.model_soup import User
 from grouper.models.audit_log import AuditLog
 from grouper.models.public_key_tag import PublicKeyTag
 from grouper.public_key import add_tag_to_public_key, DuplicateTag, get_public_key, KeyNotFound
+from grouper.service_account import can_manage_service_account
+from grouper.user_permissions import user_is_user_admin
 
 
 class PublicKeyAddTag(GrouperHandler):
+
+    @staticmethod
+    def check_access(session, actor, target):
+        return (actor.name == target.name or user_is_user_admin(session, actor) or
+            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+
     def get(self, user_id=None, name=None, key_id=None):
         user = User.get(self.session, user_id, name)
         if not user:
             return self.notfound()
 
-        if (user.name != self.current_user.name) and not self.current_user.user_admin:
+        if not self.check_access(self.session, self.current_user, user):
             return self.forbidden()
 
         try:
@@ -32,7 +40,7 @@ class PublicKeyAddTag(GrouperHandler):
         if not user:
             return self.notfound()
 
-        if (user.name != self.current_user.name) and not self.current_user.user_admin:
+        if not self.check_access(self.session, self.current_user, user):
             return self.forbidden()
 
         try:


### PR DESCRIPTION
This brings it line with the design of other modern fe handlers, and
makes it easier to change the access required for this handler.
Additionally, this fixes a bug in the existing access checks where we
were attempting to access the user_admin attribute of a User object.
This attribute no longer exists, as it was removed when the User model
was moved out of model_soup (efd88045ad1f5f3ddea1c6752fa8eef4e59f904a).
It is therefore replaced with a call to the replacement function
user_is_user_admin, which is functionally equivalent.