### PR TITLE
Add user_tokens to get_user_view_template_variables

### DIFF
--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -109,6 +109,7 @@ def get_user_view_template_vars(session, actor, user, graph):
             for perm in get_public_key_permissions(session, key)]
     ret["permissions"] = user_md.get('permissions', [])
     ret["log_entries"] = get_log_entries_by_user(session, user)
+    ret["user_tokens"] = user.tokens
 
     return ret
 


### PR DESCRIPTION
The user view used to have this available to the template, but it was
accidentally omitted when we switched to using the template variables
modules. This readds it to the template variables module, because
without this variable, the user and service account views cannot
display the user's tokens.