### PR TITLE
sync_db: Import PerfProfile so we can create its table.

### DIFF
--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -17,6 +17,10 @@ from grouper.util import get_database_url
 
 
 def sync_db_command(args):
+    # Models not implicitly or explictly imported above are explicitly imported
+    # here:
+    from grouper.models.perf_profile import PerfProfile  # noqa
+
     db_engine = get_db_engine(get_database_url(settings))
     Model.metadata.create_all(db_engine)
 


### PR DESCRIPTION
`Model.metadata.create_all()` will only create models it knows about. Perhaps
we should have a better mechanism than relying on all models to either be
directly or implicitly imported, but this unblocks things for now.