### PR TITLE
Cache translate()/compile() in get_owner_arg_list

### DIFF
--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -1,7 +1,8 @@
 from collections import defaultdict, namedtuple
 from datetime import datetime
-from fnmatch import fnmatch
+import fnmatch
 import re
+from typing import Pattern  # noqa
 
 from sqlalchemy.exc import IntegrityError
 
@@ -293,6 +294,21 @@ def get_grantable_permissions(session, restricted_ownership_permissions):
     return {p: _reduce_args(p, a) for p, a in args_by_perm.items()}
 
 
+_regex_cache = {}  # type: Dict[str, Pattern]
+
+
+def _cached_almost_fnmatch(haystack, needle):
+    # type: (str, str) -> bool
+    if "*" not in needle:
+        return haystack == needle
+    try:
+        regex = _regex_cache[needle]
+    except KeyError:
+        regex = re.compile(fnmatch.translate(needle))
+        _regex_cache[needle] = regex
+    return regex.match(haystack) is not None
+
+
 def get_owner_arg_list(session, permission, argument, owners_by_arg_by_perm=None):
     """Return the grouper group(s) responsible for approving a request for the
     given permission + argument along with the actual argument they were
@@ -313,7 +329,7 @@ def get_owner_arg_list(session, permission, argument, owners_by_arg_by_perm=None
     all_owner_arg_list = []
     owners_by_arg = owners_by_arg_by_perm[permission.name]
     for arg, owners in owners_by_arg.items():
-        if fnmatch(argument, arg):
+        if _cached_almost_fnmatch(argument, arg):
             all_owner_arg_list += [(owner, arg) for owner in owners]
 
     return all_owner_arg_list


### PR DESCRIPTION
We're spending the majority of `/permissions/requests`'s execution translating
and compiling globs to regexes. There are probably additional performance
improvements to be made, but this should make a substantial dent.

Some unscientific testing against a real dataset showed a 20x speedup on
a cold cache.