### PR TITLE
Fix source of mysql_config during Bazel build

### DIFF
--- a/thirdparty/BUILD
+++ b/thirdparty/BUILD
@@ -201,7 +201,14 @@ dbx_py_pypi_piplib(
             '_mysql_exceptions.py',
         ],
     },
+    deps = [
+        '//dpkg:libmysqlclient',
+        '//dpkg:usr/bin/mysql_config',
+    ],
     pip_deps = ['MySQL-python==1.2.5'],
+    env = {
+        'MYSQL_CONFIG': '$(ROOT)/$(location //dpkg:usr/bin/mysql_config)',
+    },
 )
 
 dbx_py_pypi_piplib(

--- a/thirdparty/BUILD.bzl
+++ b/thirdparty/BUILD.bzl
@@ -18,7 +18,14 @@ dbx_py_pypi_piplib(
 
 dbx_py_pypi_piplib(
     name = 'mysql-python',
+    deps = [
+        '//dpkg:libmysqlclient',
+        '//dpkg:usr/bin/mysql_config',
+    ],
     pip_deps = ['MySQL-python==1.2.5'],
+    env = {
+        'MYSQL_CONFIG': '$(ROOT)/$(location //dpkg:usr/bin/mysql_config)',
+    },
 )
 
 dbx_py_pypi_piplib(


### PR DESCRIPTION
The build was assuming it could use the system libmysqlclient-dev
files, including the mysql_config binary, but this is no longer
true of Dropbox Bazel builds.  Instead, get mysql_config from a
Dropbox Bazel resource.

This won't work outside of Dropbox, but the Bazel configuration in
general won't, and it shouldn't impact anyone else.