### PR TITLE
Return the request ID when adding a user to a group

### DIFF
--- a/grouper/model_soup.py
+++ b/grouper/model_soup.py
@@ -314,6 +314,8 @@ class Group(Model, CommentObjectMixin):
 
         Counter.incr(self.session, "updates")
 
+        return request.id
+
     def my_permissions(self):
 
         permissions = self.session.query(


### PR DESCRIPTION
This unbreaks the new email templates, which previously would send you
to `/groups/lfaraone-test-1/requests/None`